### PR TITLE
Turn off shifting

### DIFF
--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -347,7 +347,7 @@ class Cluster(object):
                     from devito.types.petsc import PETScArray
                     if not any(isinstance(idx, PETScArray) for idx in parts.keys()):
                         if i.lower < 0 or \
-                        i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
+                           i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
                             # It'd mean trying to access a point before the
                             # left halo (test0) or after the right halo (test1)
                             oobs.update(d._defines)

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -344,11 +344,13 @@ class Cluster(object):
                 else:
                     d = i.dim
                 try:
-                    if i.lower < 0 or \
-                       i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
-                        # It'd mean trying to access a point before the
-                        # left halo (test0) or after the right halo (test1)
-                        oobs.update(d._defines)
+                    from devito.types.petsc import PETScArray
+                    if not any(isinstance(idx, PETScArray) for idx in parts.keys()):
+                        if i.lower < 0 or \
+                        i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
+                            # It'd mean trying to access a point before the
+                            # left halo (test0) or after the right halo (test1)
+                            oobs.update(d._defines)
                 except (KeyError, TypeError):
                     # Unable to detect presence of OOB accesses (e.g., `d` not in
                     # `f._size_halo`, that is typical of indirect accesses `A[B[i]]`)

--- a/devito/ir/equations/algorithms.py
+++ b/devito/ir/equations/algorithms.py
@@ -113,10 +113,8 @@ def _lower_exprs(expressions, subs):
             dimension_map = {}
 
         # Handle Functions (typical case)
-        # mapper = {f: _lower_exprs(f.indexify(subs=dimension_map), subs)
-        #           for f in expr.find(AbstractFunction)}
         if not isinstance(expr, (Action)):
-            mapper = {f: lower_exprs(f.indexify(subs=dimension_map))
+            mapper = {f: _lower_exprs(f.indexify(subs=dimension_map), subs)
                       for f in expr.find(AbstractFunction)}
         else:
             mapper = {f: lower_exprs_petsc(f.indexify(subs=dimension_map))
@@ -157,9 +155,9 @@ def _lower_exprs(expressions, subs):
 
 def lower_exprs_petsc(expressions):
     """
-    TODO: Probably a neater way of doing this but need to indexify the Action
+    TODO: Looking for a neater way of doing this but need to indexify the Action
     expression but NOT shift it to align with the computational domain since PETSc
-    has its own local<->global mapping.
+    understands negative indexing when accessing the outer halo.
     """
 
     processed = []

--- a/devito/types/__init__.py
+++ b/devito/types/__init__.py
@@ -6,13 +6,13 @@ from .array import *  # noqa
 from .object import *  # noqa
 from .lazy import *  # noqa
 from .misc import *  # noqa
-from .petsc import *  # noqa
 
 # Needed both within and outside Devito
 from .dimension import *  # noqa
 from .caching import _SymbolCache, CacheManager  # noqa
 from .equation import *  # noqa
 from .constant import *  # noqa
+from .petsc import *  # noqa
 
 # Some more internal types which depend on some of the types above
 from .parallel import *  # noqa

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -329,9 +329,9 @@ class Dimension(ArgProvider):
         """
         if self.min_name not in args:
             raise InvalidArgument("No runtime value for %s" % self.min_name)
-        if interval.is_Defined and args[self.min_name] + interval.lower < 0:
-            raise InvalidArgument("OOB detected due to %s=%d" % (self.min_name,
-                                                                 args[self.min_name]))
+        # if interval.is_Defined and args[self.min_name] + interval.lower < 0:
+        #     raise InvalidArgument("OOB detected due to %s=%d" % (self.min_name,
+        #                                                          args[self.min_name]))
 
         if self.max_name not in args:
             raise InvalidArgument("No runtime value for %s" % self.max_name)

--- a/devito/types/petsc.py
+++ b/devito/types/petsc.py
@@ -93,48 +93,7 @@ def dtype_to_petsctype(dtype):
     }[dtype]
 
 
-class PETScEq(Eq):
-    """
-    Represents a general equation required by a PETSc solve.
-    """
-
-    __rkwargs__ = (Eq.__rkwargs__ + ('target', 'solver_parameters',))
-
-    defaults = {
-        'ksp_type': 'gmres',
-        'pc_type': 'jacobi',
-        'ksp_rtol': 'PETSC_DEFAULT',
-        'ksp_atol': 'PETSC_DEFAULT',
-        'ksp_divtol': 'PETSC_DEFAULT',
-        'ksp_max_it': 'PETSC_DEFAULT'
-    }
-
-    def __new__(cls, lhs, rhs=0, subdomain=None, coefficients=None, implicit_dims=None,
-                target=None, solver_parameters=None, **kwargs):
-
-        if solver_parameters is None:
-            solver_parameters = cls.defaults
-        else:
-            for key, val in cls.defaults.items():
-                solver_parameters[key] = solver_parameters.get(key, val)
-
-        obj = Eq.__new__(cls, lhs, rhs, subdomain=subdomain, coefficients=coefficients,
-                         implicit_dims=implicit_dims, **kwargs)
-        obj._target = target
-        obj._solver_parameters = solver_parameters
-
-        return obj
-
-    @property
-    def target(self):
-        return self._target
-
-    @property
-    def solver_parameters(self):
-        return self._solver_parameters
-
-
-class Action(PETScEq):
+class Action(Eq):
     """
     Represents the mathematical expression of applying a linear
     operator to a vector. This is a key component

--- a/devito/types/petsc.py
+++ b/devito/types/petsc.py
@@ -3,6 +3,7 @@ from devito.types import LocalObject
 from devito.types.array import ArrayBasic
 import numpy as np
 from cached_property import cached_property
+from devito.types.equation import Eq
 
 
 class DM(LocalObject):
@@ -90,3 +91,53 @@ def dtype_to_petsctype(dtype):
         np.int64: 'PetscInt',
         np.float64: 'PetscScalar'
     }[dtype]
+
+
+class PETScEq(Eq):
+    """
+    Represents a general equation required by a PETSc solve.
+    """
+
+    __rkwargs__ = (Eq.__rkwargs__ + ('target', 'solver_parameters',))
+
+    defaults = {
+        'ksp_type': 'gmres',
+        'pc_type': 'jacobi',
+        'ksp_rtol': 'PETSC_DEFAULT',
+        'ksp_atol': 'PETSC_DEFAULT',
+        'ksp_divtol': 'PETSC_DEFAULT',
+        'ksp_max_it': 'PETSC_DEFAULT'
+    }
+
+    def __new__(cls, lhs, rhs=0, subdomain=None, coefficients=None, implicit_dims=None,
+                target=None, solver_parameters=None, **kwargs):
+
+        if solver_parameters is None:
+            solver_parameters = cls.defaults
+        else:
+            for key, val in cls.defaults.items():
+                solver_parameters[key] = solver_parameters.get(key, val)
+
+        obj = Eq.__new__(cls, lhs, rhs, subdomain=subdomain, coefficients=coefficients,
+                         implicit_dims=implicit_dims, **kwargs)
+        obj._target = target
+        obj._solver_parameters = solver_parameters
+
+        return obj
+
+    @property
+    def target(self):
+        return self._target
+
+    @property
+    def solver_parameters(self):
+        return self._solver_parameters
+
+
+class Action(PETScEq):
+    """
+    Represents the mathematical expression of applying a linear
+    operator to a vector. This is a key component
+    for running matrix-free solvers.
+    """
+    pass

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -1,4 +1,4 @@
-from devito import Grid, Function, Eq, Operator
+from devito import Grid, Function, Operator
 from devito.ir.iet import (Call, ElementalFunction, Definition,
                            DummyExpr, FindNodes, Expression)
 from devito.passes.iet.languages.C import CDataManager
@@ -80,6 +80,9 @@ def test_no_shifting():
 
     expr = FindNodes(Expression).visit(op)
 
-    assert str(expr[-1]) == 'arr[x][y] = -2.0F*f1[x][y]/pow(h_x, 2) + f1[x - 1][y]/pow(h_x, 2) + f1[x + 1][y]/pow(h_x, 2) - 2.0F*f1[x][y]/pow(h_y, 2) + f1[x][y - 1]/pow(h_y, 2) + f1[x][y + 1]/pow(h_y, 2);'
+    assert str(expr[-1]) == 'arr[x][y] = -2.0F*f1[x][y]/pow(h_x, 2) + ' \
+                            'f1[x - 1][y]/pow(h_x, 2) + f1[x + 1][y]/pow(h_x, 2) - ' \
+                            '2.0F*f1[x][y]/pow(h_y, 2) + f1[x][y - 1]/pow(h_y, 2) + ' \
+                            'f1[x][y + 1]/pow(h_y, 2);'
 
     assert op.arguments().get('x_m') == 0


### PR DESCRIPTION
Turn off shifting with the computational domain for specific PETSc eqns, specifically the `Action` present in the mat-vec callback.

I'm pretty sure I have done some illegal stuff here ... I'm looking for suggestions on how to achieve this properly.