### PR TITLE
PETSc Eq

### DIFF
--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -346,7 +346,7 @@ class Cluster(object):
                 try:
                     if not isinstance(f, PETScArray):
                         if i.lower < 0 or \
-                        i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
+                           i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
                             # It'd mean trying to access a point before the
                             # left halo (test0) or after the right halo (test1)
                             oobs.update(d._defines)

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -13,7 +13,7 @@ from devito.ir.support import (PARALLEL, PARALLEL_IF_PVT, BaseGuardBoundNext,
 from devito.mpi.halo_scheme import HaloScheme, HaloTouch
 from devito.symbolics import estimate_cost
 from devito.tools import as_tuple, flatten, frozendict, infer_dtype
-from devito.types import WeakFence, CriticalRegion, PETScArray
+from devito.types import WeakFence, CriticalRegion, ArrayBasic
 
 __all__ = ["Cluster", "ClusterGroup"]
 
@@ -338,7 +338,7 @@ class Cluster(object):
         # OOB accesses
         oobs = set()
         for f, v in parts.items():
-            if not isinstance(f, PETScArray):
+            if not isinstance(f, ArrayBasic):
                 for i in v:
                     if i.dim.is_Sub:
                         d = i.dim.parent

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -13,7 +13,7 @@ from devito.ir.support import (PARALLEL, PARALLEL_IF_PVT, BaseGuardBoundNext,
 from devito.mpi.halo_scheme import HaloScheme, HaloTouch
 from devito.symbolics import estimate_cost
 from devito.tools import as_tuple, flatten, frozendict, infer_dtype
-from devito.types import WeakFence, CriticalRegion
+from devito.types import WeakFence, CriticalRegion, PETScArray
 
 __all__ = ["Cluster", "ClusterGroup"]
 
@@ -344,11 +344,12 @@ class Cluster(object):
                 else:
                     d = i.dim
                 try:
-                    if i.lower < 0 or \
-                       i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
-                        # It'd mean trying to access a point before the
-                        # left halo (test0) or after the right halo (test1)
-                        oobs.update(d._defines)
+                    if not isinstance(f, PETScArray):
+                        if i.lower < 0 or \
+                        i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
+                            # It'd mean trying to access a point before the
+                            # left halo (test0) or after the right halo (test1)
+                            oobs.update(d._defines)
                 except (KeyError, TypeError):
                     # Unable to detect presence of OOB accesses (e.g., `d` not in
                     # `f._size_halo`, that is typical of indirect accesses `A[B[i]]`)

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -347,7 +347,7 @@ class Cluster(object):
                     d = i.dim
                 try:
                     if i.lower < 0 or \
-                        i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
+                       i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
                         # It'd mean trying to access a point before the
                         # left halo (test0) or after the right halo (test1)
                         oobs.update(d._defines)

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -338,25 +338,22 @@ class Cluster(object):
         # OOB accesses
         oobs = set()
         for f, v in parts.items():
-            for i in v:
-                if i.dim.is_Sub:
-                    d = i.dim.parent
-                else:
-                    d = i.dim
-                try:
-                    # TODO: This is the one check that needs to be turned off
-                    # for PETScArrays otherwise the iteration bounds are incorrect.
-                    # Need to discuss this.
-                    if not isinstance(f, PETScArray):
+            if not isinstance(f, PETScArray):
+                for i in v:
+                    if i.dim.is_Sub:
+                        d = i.dim.parent
+                    else:
+                        d = i.dim
+                    try:
                         if i.lower < 0 or \
                            i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
                             # It'd mean trying to access a point before the
                             # left halo (test0) or after the right halo (test1)
                             oobs.update(d._defines)
-                except (KeyError, TypeError):
-                    # Unable to detect presence of OOB accesses (e.g., `d` not in
-                    # `f._size_halo`, that is typical of indirect accesses `A[B[i]]`)
-                    pass
+                    except (KeyError, TypeError):
+                        # Unable to detect presence of OOB accesses (e.g., `d` not in
+                        # `f._size_halo`, that is typical of indirect accesses `A[B[i]]`)
+                        pass
 
         # Construct the `intervals` of the DataSpace, that is a global,
         # Dimension-centric view of the data space

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -338,22 +338,23 @@ class Cluster(object):
         # OOB accesses
         oobs = set()
         for f, v in parts.items():
-            if not isinstance(f, ArrayBasic):
-                for i in v:
-                    if i.dim.is_Sub:
-                        d = i.dim.parent
-                    else:
-                        d = i.dim
-                    try:
-                        if i.lower < 0 or \
-                           i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
-                            # It'd mean trying to access a point before the
-                            # left halo (test0) or after the right halo (test1)
-                            oobs.update(d._defines)
-                    except (KeyError, TypeError):
-                        # Unable to detect presence of OOB accesses (e.g., `d` not in
-                        # `f._size_halo`, that is typical of indirect accesses `A[B[i]]`)
-                        pass
+            if isinstance(f, ArrayBasic):
+                continue
+            for i in v:
+                if i.dim.is_Sub:
+                    d = i.dim.parent
+                else:
+                    d = i.dim
+                try:
+                    if i.lower < 0 or \
+                        i.upper > f._size_nodomain[d].left + f._size_halo[d].right:
+                        # It'd mean trying to access a point before the
+                        # left halo (test0) or after the right halo (test1)
+                        oobs.update(d._defines)
+                except (KeyError, TypeError):
+                    # Unable to detect presence of OOB accesses (e.g., `d` not in
+                    # `f._size_halo`, that is typical of indirect accesses `A[B[i]]`)
+                    pass
 
         # Construct the `intervals` of the DataSpace, that is a global,
         # Dimension-centric view of the data space

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -344,6 +344,9 @@ class Cluster(object):
                 else:
                     d = i.dim
                 try:
+                    # TODO: This is the one check that needs to be turned off
+                    # for PETScArrays otherwise the iteration bounds are incorrect.
+                    # Need to discuss this.
                     if not isinstance(f, PETScArray):
                         if i.lower < 0 or \
                            i.upper > f._size_nodomain[d].left + f._size_halo[d].right:

--- a/devito/ir/equations/equation.py
+++ b/devito/ir/equations/equation.py
@@ -8,14 +8,17 @@ from devito.ir.support import (GuardFactor, Interval, IntervalGroup, IterationSp
 from devito.symbolics import IntDiv, uxreplace
 from devito.tools import Pickable, Tag, frozendict
 from devito.types import Eq, Inc, ReduceMax, ReduceMin
+from devito.types.petsc import Action, RHS
 
-__all__ = ['LoweredEq', 'ClusterizedEq', 'DummyEq', 'OpInc', 'OpMin', 'OpMax']
+__all__ = ['LoweredEq', 'ClusterizedEq', 'DummyEq', 'OpInc', 'OpMin', 'OpMax',
+           'OpAction', 'OpRHS']
 
 
 class IREq(sympy.Eq, Pickable):
 
     __rargs__ = ('lhs', 'rhs')
-    __rkwargs__ = ('ispace', 'conditionals', 'implicit_dims', 'operation')
+    __rkwargs__ = ('ispace', 'conditionals', 'implicit_dims', 'operation',
+                   'target', 'solver_parameters')
 
     @property
     def is_Scalar(self):
@@ -54,6 +57,14 @@ class IREq(sympy.Eq, Pickable):
     @property
     def operation(self):
         return self._operation
+
+    @property
+    def target(self):
+        return self._target
+
+    @property
+    def solver_parameters(self):
+        return self._solver_parameters
 
     @property
     def is_Reduction(self):
@@ -96,7 +107,9 @@ class Operation(Tag):
         reduction_mapper = {
             Inc: OpInc,
             ReduceMax: OpMax,
-            ReduceMin: OpMin
+            ReduceMin: OpMin,
+            Action: OpAction,
+            RHS: OpRHS,
         }
         try:
             return reduction_mapper[type(expr)]
@@ -113,6 +126,8 @@ class Operation(Tag):
 OpInc = Operation('+')
 OpMax = Operation('max')
 OpMin = Operation('min')
+OpAction = Operation('action')
+OpRHS = Operation('rhs')
 
 
 class LoweredEq(IREq):
@@ -206,7 +221,10 @@ class LoweredEq(IREq):
         expr._reads, expr._writes = detect_io(expr)
         expr._implicit_dims = input_expr.implicit_dims
         expr._operation = Operation.detect(input_expr)
-
+        expr._target = input_expr.target if hasattr(input_expr, 'target') else None
+        expr._solver_parameters = input_expr.solver_parameters \
+            if hasattr(input_expr, 'solver_parameters') else None
+        
         return expr
 
     @property
@@ -262,6 +280,10 @@ class ClusterizedEq(IREq):
                 expr._conditionals = kwargs.get('conditionals', frozendict())
                 expr._implicit_dims = input_expr.implicit_dims
                 expr._operation = Operation.detect(input_expr)
+                expr._target = input_expr.target \
+                    if hasattr(input_expr, 'target') else None
+                expr._solver_parameters = input_expr.solver_parameters \
+                    if hasattr(input_expr, 'solver_parameters') else None
         elif len(args) == 2:
             # origin: ClusterizedEq(lhs, rhs, **kwargs)
             expr = sympy.Eq.__new__(cls, *args, evaluate=False)

--- a/devito/ir/equations/equation.py
+++ b/devito/ir/equations/equation.py
@@ -8,10 +8,10 @@ from devito.ir.support import (GuardFactor, Interval, IntervalGroup, IterationSp
 from devito.symbolics import IntDiv, uxreplace
 from devito.tools import Pickable, Tag, frozendict
 from devito.types import Eq, Inc, ReduceMax, ReduceMin
-from devito.types.petsc import Action, RHS
+from devito.types import MatVecEq, RHSEq, LinearSolveEq
 
 __all__ = ['LoweredEq', 'ClusterizedEq', 'DummyEq', 'OpInc', 'OpMin', 'OpMax',
-           'OpAction', 'OpRHS']
+           'OpMatVec', 'OpRHS']
 
 
 class IREq(sympy.Eq, Pickable):
@@ -108,8 +108,8 @@ class Operation(Tag):
             Inc: OpInc,
             ReduceMax: OpMax,
             ReduceMin: OpMin,
-            Action: OpAction,
-            RHS: OpRHS,
+            MatVecEq: OpMatVec,
+            RHSEq: OpRHS,
         }
         try:
             return reduction_mapper[type(expr)]
@@ -126,7 +126,11 @@ class Operation(Tag):
 OpInc = Operation('+')
 OpMax = Operation('max')
 OpMin = Operation('min')
-OpAction = Operation('action')
+
+# Operations required by a Linear Solve of the form Ax=b:
+# Application of linear operator on a vector -> op for matrix-vector multiplication.
+OpMatVec = Operation('matvec')
+# Building the right-hand side of linear system.
 OpRHS = Operation('rhs')
 
 
@@ -221,9 +225,10 @@ class LoweredEq(IREq):
         expr._reads, expr._writes = detect_io(expr)
         expr._implicit_dims = input_expr.implicit_dims
         expr._operation = Operation.detect(input_expr)
-        expr._target = input_expr.target if hasattr(input_expr, 'target') else None
+        expr._target = input_expr.target \
+            if isinstance(input_expr, LinearSolveEq) else None
         expr._solver_parameters = input_expr.solver_parameters \
-            if hasattr(input_expr, 'solver_parameters') else None
+            if isinstance(input_expr, LinearSolveEq) else None
 
         return expr
 
@@ -281,9 +286,9 @@ class ClusterizedEq(IREq):
                 expr._implicit_dims = input_expr.implicit_dims
                 expr._operation = Operation.detect(input_expr)
                 expr._target = input_expr.target \
-                    if hasattr(input_expr, 'target') else None
+                    if isinstance(input_expr, LinearSolveEq) else None
                 expr._solver_parameters = input_expr.solver_parameters \
-                    if hasattr(input_expr, 'solver_parameters') else None
+                    if isinstance(input_expr, LinearSolveEq) else None
         elif len(args) == 2:
             # origin: ClusterizedEq(lhs, rhs, **kwargs)
             expr = sympy.Eq.__new__(cls, *args, evaluate=False)

--- a/devito/ir/equations/equation.py
+++ b/devito/ir/equations/equation.py
@@ -204,13 +204,13 @@ class LoweredEq(IREq):
             if d.factor is not None:
                 expr = uxreplace(expr, {d: IntDiv(d.index, d.factor)})
         conditionals = frozendict(conditionals)
-        # from IPython import embed; embed()
+
         # Lower all Differentiable operations into SymPy operations
         rhs = diff2sympy(expr.rhs)
 
         # Finally create the LoweredEq with all metadata attached
         expr = super().__new__(cls, expr.lhs, rhs, evaluate=False)
-        # from IPython import embed; embed()
+
         expr._ispace = ispace
         expr._conditionals = conditionals
         expr._reads, expr._writes = detect_io(expr)

--- a/devito/ir/equations/equation.py
+++ b/devito/ir/equations/equation.py
@@ -8,7 +8,7 @@ from devito.ir.support import (GuardFactor, Interval, IntervalGroup, IterationSp
 from devito.symbolics import IntDiv, uxreplace
 from devito.tools import Pickable, Tag, frozendict
 from devito.types import Eq, Inc, ReduceMax, ReduceMin
-from devito.types import MatVecEq, RHSEq, LinearSolveEq
+from devito.types import MatVecEq, RHSEq
 
 __all__ = ['LoweredEq', 'ClusterizedEq', 'DummyEq', 'OpInc', 'OpMin', 'OpMax',
            'OpMatVec', 'OpRHS']
@@ -17,8 +17,7 @@ __all__ = ['LoweredEq', 'ClusterizedEq', 'DummyEq', 'OpInc', 'OpMin', 'OpMax',
 class IREq(sympy.Eq, Pickable):
 
     __rargs__ = ('lhs', 'rhs')
-    __rkwargs__ = ('ispace', 'conditionals', 'implicit_dims', 'operation',
-                   'target', 'solver_parameters')
+    __rkwargs__ = ('ispace', 'conditionals', 'implicit_dims', 'operation')
 
     @property
     def is_Scalar(self):
@@ -57,14 +56,6 @@ class IREq(sympy.Eq, Pickable):
     @property
     def operation(self):
         return self._operation
-
-    @property
-    def target(self):
-        return self._target
-
-    @property
-    def solver_parameters(self):
-        return self._solver_parameters
 
     @property
     def is_Reduction(self):
@@ -213,22 +204,18 @@ class LoweredEq(IREq):
             if d.factor is not None:
                 expr = uxreplace(expr, {d: IntDiv(d.index, d.factor)})
         conditionals = frozendict(conditionals)
-
+        # from IPython import embed; embed()
         # Lower all Differentiable operations into SymPy operations
         rhs = diff2sympy(expr.rhs)
 
         # Finally create the LoweredEq with all metadata attached
         expr = super().__new__(cls, expr.lhs, rhs, evaluate=False)
-
+        # from IPython import embed; embed()
         expr._ispace = ispace
         expr._conditionals = conditionals
         expr._reads, expr._writes = detect_io(expr)
         expr._implicit_dims = input_expr.implicit_dims
         expr._operation = Operation.detect(input_expr)
-        expr._target = input_expr.target \
-            if isinstance(input_expr, LinearSolveEq) else None
-        expr._solver_parameters = input_expr.solver_parameters \
-            if isinstance(input_expr, LinearSolveEq) else None
 
         return expr
 
@@ -285,10 +272,6 @@ class ClusterizedEq(IREq):
                 expr._conditionals = kwargs.get('conditionals', frozendict())
                 expr._implicit_dims = input_expr.implicit_dims
                 expr._operation = Operation.detect(input_expr)
-                expr._target = input_expr.target \
-                    if isinstance(input_expr, LinearSolveEq) else None
-                expr._solver_parameters = input_expr.solver_parameters \
-                    if isinstance(input_expr, LinearSolveEq) else None
         elif len(args) == 2:
             # origin: ClusterizedEq(lhs, rhs, **kwargs)
             expr = sympy.Eq.__new__(cls, *args, evaluate=False)

--- a/devito/ir/equations/equation.py
+++ b/devito/ir/equations/equation.py
@@ -224,7 +224,7 @@ class LoweredEq(IREq):
         expr._target = input_expr.target if hasattr(input_expr, 'target') else None
         expr._solver_parameters = input_expr.solver_parameters \
             if hasattr(input_expr, 'solver_parameters') else None
-        
+
         return expr
 
     @property

--- a/devito/ir/iet/algorithms.py
+++ b/devito/ir/iet/algorithms.py
@@ -4,7 +4,7 @@ from devito.ir.iet import (Expression, Increment, Iteration, List, Conditional, 
                            Section, HaloSpot, ExpressionBundle, MatVecAction,
                            RHSLinearSystem)
 from devito.tools import timed_pass
-from devito.types import PETScRHS
+from devito.types import LinearSolveExpr
 from devito.ir.equations import OpMatVec, OpRHS
 
 __all__ = ['iet_build']
@@ -27,7 +27,7 @@ def iet_build(stree):
             for e in i.exprs:
                 if e.is_Increment:
                     exprs.append(Increment(e))
-                elif isinstance(e.rhs, PETScRHS):
+                elif isinstance(e.rhs, LinearSolveExpr):
                     exprs.append(Op_to_Expr(e.operation)(e, operation=e.operation))
                 else:
                     exprs.append(Expression(e, operation=e.operation))

--- a/devito/ir/iet/algorithms.py
+++ b/devito/ir/iet/algorithms.py
@@ -28,7 +28,7 @@ def iet_build(stree):
                 if e.is_Increment:
                     exprs.append(Increment(e))
                 elif isinstance(e.rhs, LinearSolveExpr):
-                    exprs.append(Op_to_Expr(e.operation)(e, operation=e.operation))
+                    exprs.append(mapper[e.operation](e, operation=e.operation))
                 else:
                     exprs.append(Expression(e, operation=e.operation))
             body = ExpressionBundle(i.ispace, i.ops, i.traffic, body=exprs)
@@ -58,10 +58,7 @@ def iet_build(stree):
     assert False
 
 
-def Op_to_Expr(operation):
-    """Map Eq operation to IET Expression type."""
-
-    return {
-        OpMatVec: MatVecAction,
-        OpRHS: RHSLinearSystem
-    }[operation]
+# Mapping special Eq operations to their corresponding IET Expression subclass types.
+# These operations correspond to subclasses of Eq utilised within PETScSolve.
+mapper = {OpMatVec: MatVecAction,
+          OpRHS: RHSLinearSystem}

--- a/devito/ir/iet/algorithms.py
+++ b/devito/ir/iet/algorithms.py
@@ -28,7 +28,7 @@ def iet_build(stree):
                 if e.is_Increment:
                     exprs.append(Increment(e))
                 elif isinstance(e.rhs, LinearSolveExpr):
-                    exprs.append(mapper[e.operation](e, operation=e.operation))
+                    exprs.append(linsolve_mapper[e.operation](e, operation=e.operation))
                 else:
                     exprs.append(Expression(e, operation=e.operation))
             body = ExpressionBundle(i.ispace, i.ops, i.traffic, body=exprs)
@@ -60,5 +60,5 @@ def iet_build(stree):
 
 # Mapping special Eq operations to their corresponding IET Expression subclass types.
 # These operations correspond to subclasses of Eq utilised within PETScSolve.
-mapper = {OpMatVec: MatVecAction,
-          OpRHS: RHSLinearSystem}
+linsolve_mapper = {OpMatVec: MatVecAction,
+                   OpRHS: RHSLinearSystem}

--- a/devito/ir/iet/algorithms.py
+++ b/devito/ir/iet/algorithms.py
@@ -1,8 +1,9 @@
 from collections import OrderedDict
 
 from devito.ir.iet import (Expression, Increment, Iteration, List, Conditional, SyncSpot,
-                           Section, HaloSpot, ExpressionBundle)
+                           Section, HaloSpot, ExpressionBundle, ActionExpr, RHSExpr)
 from devito.tools import timed_pass
+from devito.ir.equations import OpAction, OpRHS
 
 __all__ = ['iet_build']
 
@@ -24,6 +25,12 @@ def iet_build(stree):
             for e in i.exprs:
                 if e.is_Increment:
                     exprs.append(Increment(e))
+                elif e.operation is OpAction:
+                    exprs.append(ActionExpr(e, operation=e.operation, target=e.target,
+                                            solver_parameters=e.solver_parameters))
+                elif e.operation is OpRHS:
+                    exprs.append(RHSExpr(e, operation=e.operation, target=e.target,
+                                         solver_parameters=e.solver_parameters))
                 else:
                     exprs.append(Expression(e, operation=e.operation))
             body = ExpressionBundle(i.ispace, i.ops, i.traffic, body=exprs)

--- a/devito/ir/iet/algorithms.py
+++ b/devito/ir/iet/algorithms.py
@@ -27,13 +27,9 @@ def iet_build(stree):
                 if e.is_Increment:
                     exprs.append(Increment(e))
                 elif e.operation is OpMatVec:
-                    exprs.append(MatVecAction(e, operation=e.operation,
-                                              target=e.target,
-                                              solver_parameters=e.solver_parameters))
+                    exprs.append(MatVecAction(e, operation=e.operation))
                 elif e.operation is OpRHS:
-                    exprs.append(RHSLinearSystem(e, operation=e.operation,
-                                                 target=e.target,
-                                                 solver_parameters=e.solver_parameters))
+                    exprs.append(RHSLinearSystem(e, operation=e.operation))
                 else:
                     exprs.append(Expression(e, operation=e.operation))
             body = ExpressionBundle(i.ispace, i.ops, i.traffic, body=exprs)

--- a/devito/ir/iet/algorithms.py
+++ b/devito/ir/iet/algorithms.py
@@ -1,9 +1,10 @@
 from collections import OrderedDict
 
 from devito.ir.iet import (Expression, Increment, Iteration, List, Conditional, SyncSpot,
-                           Section, HaloSpot, ExpressionBundle, ActionExpr, RHSExpr)
+                           Section, HaloSpot, ExpressionBundle, MatVecAction,
+                           RHSLinearSystem)
 from devito.tools import timed_pass
-from devito.ir.equations import OpAction, OpRHS
+from devito.ir.equations import OpMatVec, OpRHS
 
 __all__ = ['iet_build']
 
@@ -25,12 +26,14 @@ def iet_build(stree):
             for e in i.exprs:
                 if e.is_Increment:
                     exprs.append(Increment(e))
-                elif e.operation is OpAction:
-                    exprs.append(ActionExpr(e, operation=e.operation, target=e.target,
-                                            solver_parameters=e.solver_parameters))
+                elif e.operation is OpMatVec:
+                    exprs.append(MatVecAction(e, operation=e.operation,
+                                              target=e.target,
+                                              solver_parameters=e.solver_parameters))
                 elif e.operation is OpRHS:
-                    exprs.append(RHSExpr(e, operation=e.operation, target=e.target,
-                                         solver_parameters=e.solver_parameters))
+                    exprs.append(RHSLinearSystem(e, operation=e.operation,
+                                                 target=e.target,
+                                                 solver_parameters=e.solver_parameters))
                 else:
                     exprs.append(Expression(e, operation=e.operation))
             body = ExpressionBundle(i.ispace, i.ops, i.traffic, body=exprs)

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -485,8 +485,11 @@ class Increment(AugmentedExpression):
 
 
 class LinearSolverExpression(Expression):
-    """General expression required by a matrix-free linear solve of the
-    form Ax=b."""
+
+    """
+    General expression required by a matrix-free linear solve of the
+    form Ax=b.
+    """
 
     def __init__(self, expr, pragmas=None, operation=None):
         super().__init__(expr, pragmas=pragmas, operation=operation)
@@ -494,11 +497,19 @@ class LinearSolverExpression(Expression):
 
 class MatVecAction(LinearSolverExpression):
 
+    """
+    Expression representing matrix-vector multiplication.
+    """
+
     def __init__(self, expr, pragmas=None, operation=OpMatVec):
         super().__init__(expr, pragmas=pragmas, operation=operation)
 
 
 class RHSLinearSystem(LinearSolverExpression):
+
+    """
+    Expression to build the RHS of a linear system.
+    """
 
     def __init__(self, expr, pragmas=None, operation=OpRHS):
         super().__init__(expr, pragmas=pragmas, operation=operation)

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -10,7 +10,7 @@ import cgen as c
 from sympy import IndexedBase, sympify
 
 from devito.data import FULL
-from devito.ir.equations import DummyEq, OpInc, OpMin, OpMax, OpAction, OpRHS
+from devito.ir.equations import DummyEq, OpInc, OpMin, OpMax, OpMatVec, OpRHS
 from devito.ir.support import (INBOUND, SEQUENTIAL, PARALLEL, PARALLEL_IF_ATOMIC,
                                PARALLEL_IF_PVT, VECTORIZED, AFFINE, Property,
                                Forward, detect_io)
@@ -28,7 +28,7 @@ __all__ = ['Node', 'MultiTraversable', 'Block', 'Expression', 'Callable',
            'Increment', 'Return', 'While', 'ListMajor', 'ParallelIteration',
            'ParallelBlock', 'Dereference', 'Lambda', 'SyncSpot', 'Pragma',
            'DummyExpr', 'BlankLine', 'ParallelTree', 'BusyWait', 'UsingNamespace',
-           'CallableBody', 'Transfer', 'Callback', 'ActionExpr', 'RHSExpr']
+           'CallableBody', 'Transfer', 'Callback', 'MatVecAction', 'RHSLinearSystem']
 
 # First-class IET nodes
 
@@ -484,22 +484,31 @@ class Increment(AugmentedExpression):
         super().__init__(expr, pragmas=pragmas, operation=OpInc)
 
 
-class ActionExpr(Expression):
+class LinearSolverExpression(Expression):
+    """General expression required by a matrix-free linear solve of the
+    form Ax=b."""
 
-    def __init__(self, expr, pragmas=None, operation=OpAction,
+    def __init__(self, expr, pragmas=None, operation=None,
                  target=None, solver_parameters=None):
         super().__init__(expr, pragmas=pragmas, operation=operation)
         self.target = target
         self.solver_parameters = solver_parameters
 
 
-class RHSExpr(Expression):
+class MatVecAction(LinearSolverExpression):
+
+    def __init__(self, expr, pragmas=None, operation=OpMatVec,
+                 target=None, solver_parameters=None):
+        super().__init__(expr, pragmas=pragmas, operation=operation,
+                         target=target, solver_parameters=solver_parameters)
+
+
+class RHSLinearSystem(LinearSolverExpression):
 
     def __init__(self, expr, pragmas=None, operation=OpRHS,
                  target=None, solver_parameters=None):
-        super().__init__(expr, pragmas=pragmas, operation=operation)
-        self.target = target
-        self.solver_parameters = solver_parameters
+        super().__init__(expr, pragmas=pragmas, operation=operation,
+                         target=target, solver_parameters=solver_parameters)
 
 
 class Iteration(Node):

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -488,27 +488,20 @@ class LinearSolverExpression(Expression):
     """General expression required by a matrix-free linear solve of the
     form Ax=b."""
 
-    def __init__(self, expr, pragmas=None, operation=None,
-                 target=None, solver_parameters=None):
+    def __init__(self, expr, pragmas=None, operation=None):
         super().__init__(expr, pragmas=pragmas, operation=operation)
-        self.target = target
-        self.solver_parameters = solver_parameters
 
 
 class MatVecAction(LinearSolverExpression):
 
-    def __init__(self, expr, pragmas=None, operation=OpMatVec,
-                 target=None, solver_parameters=None):
-        super().__init__(expr, pragmas=pragmas, operation=operation,
-                         target=target, solver_parameters=solver_parameters)
+    def __init__(self, expr, pragmas=None, operation=OpMatVec):
+        super().__init__(expr, pragmas=pragmas, operation=operation)
 
 
 class RHSLinearSystem(LinearSolverExpression):
 
-    def __init__(self, expr, pragmas=None, operation=OpRHS,
-                 target=None, solver_parameters=None):
-        super().__init__(expr, pragmas=pragmas, operation=operation,
-                         target=target, solver_parameters=solver_parameters)
+    def __init__(self, expr, pragmas=None, operation=OpRHS):
+        super().__init__(expr, pragmas=pragmas, operation=operation)
 
 
 class Iteration(Node):

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -487,8 +487,8 @@ class Increment(AugmentedExpression):
 class LinearSolverExpression(Expression):
 
     """
-    General expression required by a matrix-free linear solve of the
-    form Ax=b.
+    Base class for general expressions required by a
+    matrix-free linear solve of the form Ax=b.
     """
     pass
 

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -490,9 +490,7 @@ class LinearSolverExpression(Expression):
     General expression required by a matrix-free linear solve of the
     form Ax=b.
     """
-
-    def __init__(self, expr, pragmas=None, operation=None):
-        super().__init__(expr, pragmas=pragmas, operation=operation)
+    pass
 
 
 class MatVecAction(LinearSolverExpression):

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -10,7 +10,7 @@ import cgen as c
 from sympy import IndexedBase, sympify
 
 from devito.data import FULL
-from devito.ir.equations import DummyEq, OpInc, OpMin, OpMax
+from devito.ir.equations import DummyEq, OpInc, OpMin, OpMax, OpAction, OpRHS
 from devito.ir.support import (INBOUND, SEQUENTIAL, PARALLEL, PARALLEL_IF_ATOMIC,
                                PARALLEL_IF_PVT, VECTORIZED, AFFINE, Property,
                                Forward, detect_io)
@@ -28,7 +28,7 @@ __all__ = ['Node', 'MultiTraversable', 'Block', 'Expression', 'Callable',
            'Increment', 'Return', 'While', 'ListMajor', 'ParallelIteration',
            'ParallelBlock', 'Dereference', 'Lambda', 'SyncSpot', 'Pragma',
            'DummyExpr', 'BlankLine', 'ParallelTree', 'BusyWait', 'UsingNamespace',
-           'CallableBody', 'Transfer', 'Callback']
+           'CallableBody', 'Transfer', 'Callback', 'ActionExpr', 'RHSExpr']
 
 # First-class IET nodes
 
@@ -482,6 +482,24 @@ class Increment(AugmentedExpression):
 
     def __init__(self, expr, pragmas=None):
         super().__init__(expr, pragmas=pragmas, operation=OpInc)
+
+
+class ActionExpr(Expression):
+
+    def __init__(self, expr, pragmas=None, operation=OpAction,
+                 target=None, solver_parameters=None):
+        super().__init__(expr, pragmas=pragmas, operation=operation)
+        self.target = target
+        self.solver_parameters = solver_parameters
+
+
+class RHSExpr(Expression):
+
+    def __init__(self, expr, pragmas=None, operation=OpRHS,
+                 target=None, solver_parameters=None):
+        super().__init__(expr, pragmas=pragmas, operation=operation)
+        self.target = target
+        self.solver_parameters = solver_parameters
 
 
 class Iteration(Node):

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -22,7 +22,7 @@ from devito.mpi import MPI
 from devito.parameters import configuration
 from devito.passes import (Graph, lower_index_derivatives, generate_implicit,
                            generate_macros, minimize_symbols, unevaluate,
-                           error_mapper)
+                           error_mapper, lower_petsc)
 from devito.symbolics import estimate_cost
 from devito.tools import (DAG, OrderedSet, Signer, ReducerMap, as_tuple, flatten,
                           filter_sorted, frozendict, is_integer, split, timed_pass,
@@ -461,6 +461,8 @@ class Operator(Callable):
         # Lower IET to a target-specific IET
         graph = Graph(iet, **kwargs)
         graph = cls._specialize_iet(graph, **kwargs)
+
+        lower_petsc(graph, **kwargs)
 
         # Instrument the IET for C-level profiling
         # Note: this is postponed until after _specialize_iet because during

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -334,7 +334,7 @@ class Operator(Callable):
         expressions = lower_exprs(expressions, **kwargs)
 
         processed = [LoweredEq(i) for i in expressions]
-        # from IPython import embed; embed()
+
         return processed
 
     # Compilation -- Cluster level

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -334,7 +334,7 @@ class Operator(Callable):
         expressions = lower_exprs(expressions, **kwargs)
 
         processed = [LoweredEq(i) for i in expressions]
-
+        # from IPython import embed; embed()
         return processed
 
     # Compilation -- Cluster level

--- a/devito/passes/iet/__init__.py
+++ b/devito/passes/iet/__init__.py
@@ -8,3 +8,4 @@ from .asynchrony import *  # noqa
 from .instrument import *  # noqa
 from .languages import *  # noqa
 from .errors import *  # noqa
+from .petsc import *  # noqa

--- a/devito/passes/iet/petsc.py
+++ b/devito/passes/iet/petsc.py
@@ -8,4 +8,7 @@ def lower_petsc(iet, **kwargs):
 
     # TODO: This is a placeholder for the actual PETSc lowering.
 
+    # TODO: Drop the LinearSolveExpr's using .args[0] so that _rebuild doesn't
+    # appear in ccode
+
     return iet, {}

--- a/devito/passes/iet/petsc.py
+++ b/devito/passes/iet/petsc.py
@@ -1,6 +1,5 @@
 from devito.passes.iet.engine import iet_pass
 
-
 __all__ = ['lower_petsc']
 
 
@@ -8,6 +7,5 @@ __all__ = ['lower_petsc']
 def lower_petsc(iet, **kwargs):
 
     # TODO: This is a placeholder for the actual PETSc lowering.
-    # action_expr = FindNodes(MatVecAction).visit(iet)
-    # rhs_expr = FindNodes(RHSExpr).visit(iet)
+
     return iet, {}

--- a/devito/passes/iet/petsc.py
+++ b/devito/passes/iet/petsc.py
@@ -1,0 +1,13 @@
+from devito.passes.iet.engine import iet_pass
+
+__all__ = ['lower_petsc']
+
+
+@iet_pass
+def lower_petsc(iet, **kwargs):
+
+    # TODO: This is a placeholder for the actual PETSc lowering.
+    # action_expr = FindNodes(ActionExpr).visit(iet)
+    # rhs_expr = FindNodes(RHSExpr).visit(iet)
+
+    return iet, {}

--- a/devito/passes/iet/petsc.py
+++ b/devito/passes/iet/petsc.py
@@ -1,5 +1,6 @@
 from devito.passes.iet.engine import iet_pass
 
+
 __all__ = ['lower_petsc']
 
 
@@ -7,7 +8,6 @@ __all__ = ['lower_petsc']
 def lower_petsc(iet, **kwargs):
 
     # TODO: This is a placeholder for the actual PETSc lowering.
-    # action_expr = FindNodes(ActionExpr).visit(iet)
+    # action_expr = FindNodes(MatVecAction).visit(iet)
     # rhs_expr = FindNodes(RHSExpr).visit(iet)
-
     return iet, {}

--- a/devito/symbolics/printer.py
+++ b/devito/symbolics/printer.py
@@ -181,7 +181,7 @@ class CodePrinter(C99CodePrinter):
     def _print_Differentiable(self, expr):
         return "(%s)" % self._print(expr._expr)
 
-    def _print_PETScRHS(self, expr):
+    def _print_LinearSolveExpr(self, expr):
         return "%s" % self._print(expr._expr)
 
     _print_EvalDerivative = C99CodePrinter._print_Add

--- a/devito/symbolics/printer.py
+++ b/devito/symbolics/printer.py
@@ -181,9 +181,6 @@ class CodePrinter(C99CodePrinter):
     def _print_Differentiable(self, expr):
         return "(%s)" % self._print(expr._expr)
 
-    def _print_LinearSolveExpr(self, expr):
-        return "%s" % self._print(expr._expr)
-
     _print_EvalDerivative = C99CodePrinter._print_Add
 
     def _print_CallFromPointer(self, expr):

--- a/devito/symbolics/printer.py
+++ b/devito/symbolics/printer.py
@@ -181,6 +181,9 @@ class CodePrinter(C99CodePrinter):
     def _print_Differentiable(self, expr):
         return "(%s)" % self._print(expr._expr)
 
+    def _print_PETScRHS(self, expr):
+        return "%s" % self._print(expr._expr)
+
     _print_EvalDerivative = C99CodePrinter._print_Add
 
     def _print_CallFromPointer(self, expr):

--- a/devito/types/petsc.py
+++ b/devito/types/petsc.py
@@ -199,8 +199,8 @@ class LinearSolveExpr(sympy.Function, Reconstructable):
     def _sympystr(self, printer):
         return str(self)
 
-    def _hashable_content(self):
-        return super()._hashable_content() + (self.expr, self.target)
+    def __hash__(self):
+        return hash(self.target)
 
     @property
     def expr(self):

--- a/devito/types/petsc.py
+++ b/devito/types/petsc.py
@@ -182,7 +182,7 @@ class RHS(PETScEq):
 def PETScSolve(eq, target, bcs=None, solver_parameters=None, **kwargs):
 
     # TODO: This is a placeholder for the actual implementation. To start,
-    # track a single PETScEq i.e an 'Action' through the Operator.
+    # track different PETScEq's (Action, RHS) through the Operator.
 
     y_matvec = PETScArray(name='y_matvec_'+str(target.name), dtype=target.dtype,
                           dimensions=target.dimensions,

--- a/devito/types/petsc.py
+++ b/devito/types/petsc.py
@@ -157,17 +157,17 @@ def PETScSolve(eq, target, bcs=None, solver_parameters=None, **kwargs):
                        shape=target.shape, liveness='eager')
 
     # # TODO: Extend to rearrange equation for implicit time stepping.
-    matvecaction = MatVecEq(y_matvec, PETScRHS(eq.lhs.subs(target, x_matvec),
+    matvecaction = MatVecEq(y_matvec, LinearSolveExpr(eq.lhs.subs(target, x_matvec),
                             target=target, solver_parameters=solver_parameters),
                             subdomain=eq.subdomain)
 
-    rhs = RHSEq(b_tmp, PETScRHS(eq.rhs, target=target,
+    rhs = RHSEq(b_tmp, LinearSolveExpr(eq.rhs, target=target,
                 solver_parameters=solver_parameters), subdomain=eq.subdomain)
 
     return [matvecaction] + [rhs]
 
 
-class PETScRHS(sympy.Expr, Reconstructable):
+class LinearSolveExpr(sympy.Expr, Reconstructable):
 
     __rargs__ = ('expr', 'target', 'solver_parameters',)
 

--- a/devito/types/petsc.py
+++ b/devito/types/petsc.py
@@ -185,7 +185,7 @@ class LinearSolveExpr(sympy.Function, Reconstructable):
             for key, val in cls.defaults.items():
                 solver_parameters[key] = solver_parameters.get(key, val)
 
-        obj = sympy.Function.__new__(cls, expr)
+        obj = super().__new__(cls, expr)
         obj._expr = expr
         obj._target = target
         obj._solver_parameters = solver_parameters

--- a/devito/types/petsc.py
+++ b/devito/types/petsc.py
@@ -7,6 +7,7 @@ from devito.finite_differences import Differentiable
 from devito.types.basic import AbstractFunction
 from devito.finite_differences.tools import fd_weights_registry
 
+
 class DM(LocalObject):
     """
     PETSc Data Management object (DM).
@@ -159,7 +160,7 @@ class PETScEq(Eq):
     @property
     def solver_parameters(self):
         return self._solver_parameters
-    
+
 
 class Action(PETScEq):
     """
@@ -186,24 +187,23 @@ def PETScSolve(eq, target, bcs=None, solver_parameters=None, **kwargs):
     y_matvec = PETScArray(name='y_matvec_'+str(target.name), dtype=target.dtype,
                           dimensions=target.dimensions,
                           shape=target.shape, liveness='eager')
-    
+
     x_matvec = PETScArray(name='x_matvec_'+str(target.name), dtype=target.dtype,
                           dimensions=target.dimensions,
                           shape=target.shape, liveness='eager')
-    
+
     b_tmp = PETScArray(name='b_tmp_'+str(target.name), dtype=target.dtype,
                        dimensions=target.dimensions,
                        shape=target.shape, liveness='eager')
-    
-    # TODO: Extend to rearrange equation for implicit time stepping. 
+
+    # TODO: Extend to rearrange equation for implicit time stepping.
     action_tmp = Action(y_matvec, eq.lhs, subdomain=eq.subdomain, target=target,
                         solver_parameters=solver_parameters)
-    
+
     rhs = RHS(b_tmp, eq.rhs, subdomain=eq.subdomain, target=target,
               solver_parameters=solver_parameters)
 
     # Only need symbolic representation of equation in mat-vec action callback.
     action = action_tmp.subs(target, x_matvec)
 
-    
     return [action] + [rhs]

--- a/devito/types/petsc.py
+++ b/devito/types/petsc.py
@@ -167,16 +167,17 @@ def PETScSolve(eq, target, bcs=None, solver_parameters=None, **kwargs):
     return [matvecaction] + [rhs]
 
 
-class LinearSolveExpr(sympy.Expr, Reconstructable):
+class LinearSolveExpr(sympy.Function, Reconstructable):
 
-    __rargs__ = ('expr', 'target', 'solver_parameters',)
+    __rargs__ = ('expr',)
+    __rkwargs__ = ('target', 'solver_parameters',)
 
     defaults = {
         'ksp_type': 'gmres',
         'pc_type': 'jacobi'
     }
 
-    def __new__(cls, expr, target, solver_parameters, **kwargs):
+    def __new__(cls, expr, target=None, solver_parameters=None, **kwargs):
 
         if solver_parameters is None:
             solver_parameters = cls.defaults
@@ -184,15 +185,14 @@ class LinearSolveExpr(sympy.Expr, Reconstructable):
             for key, val in cls.defaults.items():
                 solver_parameters[key] = solver_parameters.get(key, val)
 
-        obj = sympy.Expr.__new__(cls, expr)
+        obj = sympy.Function.__new__(cls, expr)
         obj._expr = expr
         obj._target = target
         obj._solver_parameters = solver_parameters
-
         return obj
 
     def __repr__(self):
-        return "%s" % self.expr
+        return "%s(%s)" % (self.__class__.__name__, self.expr)
 
     __str__ = __repr__
 
@@ -200,7 +200,7 @@ class LinearSolveExpr(sympy.Expr, Reconstructable):
         return str(self)
 
     def _hashable_content(self):
-        return super()._hashable_content() + (self.target,)
+        return super()._hashable_content() + (self.expr, self.target)
 
     @property
     def expr(self):

--- a/devito/types/petsc.py
+++ b/devito/types/petsc.py
@@ -127,14 +127,10 @@ class PETScEq(Eq):
 
     __rkwargs__ = (Eq.__rkwargs__ + ('target', 'solver_parameters',))
 
-    # TODO: Add more solver parameters
+    # TODO: Add more default solver parameters.
     defaults = {
         'ksp_type': 'gmres',
-        'pc_type': 'jacobi',
-        'ksp_rtol': 'PETSC_DEFAULT',
-        'ksp_atol': 'PETSC_DEFAULT',
-        'ksp_divtol': 'PETSC_DEFAULT',
-        'ksp_max_it': 'PETSC_DEFAULT'
+        'pc_type': 'jacobi'
     }
 
     def __new__(cls, lhs, rhs=0, subdomain=None, coefficients=None, implicit_dims=None,

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -1,6 +1,6 @@
 from devito import Grid, Function, Eq, Operator
 from devito.ir.iet import (Call, ElementalFunction, Definition, DummyExpr,
-                           ActionExpr, FindNodes, RHSExpr)
+                           MatVecAction, FindNodes, RHSLinearSystem)
 from devito.passes.iet.languages.C import CDataManager
 from devito.types import (DM, Mat, Vec, PetscMPIInt, KSP,
                           PC, KSPConvergedReason, PETScArray, PETScSolve)
@@ -104,9 +104,9 @@ def test_petsc_solve():
 
     op = Operator(petsc, opt='noop')
 
-    action_expr = FindNodes(ActionExpr).visit(op)
+    action_expr = FindNodes(MatVecAction).visit(op)
 
-    rhs_expr = FindNodes(RHSExpr).visit(op)
+    rhs_expr = FindNodes(RHSLinearSystem).visit(op)
 
     assert str(action_expr[-1]) == 'y_matvec_f[x][y] =' + \
         ' -2.0F*x_matvec_f[x][y]/pow(h_x, 2) + x_matvec_f[x - 1][y]/pow(h_x, 2)' + \

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -120,3 +120,13 @@ def test_petsc_solve():
     assert op.arguments().get('y_m') == 0
     assert op.arguments().get('y_M') == 1
     assert op.arguments().get('x_M') == 1
+
+    # Check the target
+    assert rhs_expr[-1].expr.rhs.target == f
+    assert action_expr[-1].expr.rhs.target == f
+
+    # Check the solver parameters
+    assert rhs_expr[-1].expr.rhs.solver_parameters == \
+        {'ksp_type': 'gmres', 'pc_type': 'jacobi'}
+    assert action_expr[-1].expr.rhs.solver_parameters == \
+        {'ksp_type': 'gmres', 'pc_type': 'jacobi'}

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -88,3 +88,16 @@ def test_petsc_subs():
     assert str(eqn_subs.rhs.evaluate) == '-2.0*arr(x, y)/h_x**2' + \
         ' + arr(x - h_x, y)/h_x**2 + arr(x + h_x, y)/h_x**2 - 2.0*arr(x, y)/h_y**2' + \
         ' + arr(x, y - h_y)/h_y**2 + arr(x, y + h_y)/h_y**2'
+    
+
+# def test_petsc_solve():
+
+#     grid = Grid((2, 2))
+
+#     f1 = Function(name='f1', grid=grid, space_order=2)
+#     f2 = Function(name='f2', grid=grid, space_order=2)
+
+#     arr = PETScArray(name='arr', dimensions=f2.dimensions, dtype=f2.dtype)
+
+#     eqn = Eq(f1, f2.laplace)
+#     eqn_subs = eqn.subs(f2, arr)

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -89,7 +89,7 @@ def test_petsc_subs():
     assert str(eqn_subs.rhs.evaluate) == '-2.0*arr(x, y)/h_x**2' + \
         ' + arr(x - h_x, y)/h_x**2 + arr(x + h_x, y)/h_x**2 - 2.0*arr(x, y)/h_y**2' + \
         ' + arr(x, y - h_y)/h_y**2 + arr(x, y + h_y)/h_y**2'
-    
+
 
 def test_petsc_solve():
 
@@ -108,11 +108,11 @@ def test_petsc_solve():
 
     rhs_expr = FindNodes(RHSExpr).visit(op)
 
-    assert str(action_expr[-1]) == 'y_matvec_f[x][y] = -2.0F*x_matvec_f[x][y]/pow(h_x, 2)' + \
-        ' + x_matvec_f[x - 1][y]/pow(h_x, 2) + x_matvec_f[x + 1][y]/pow(h_x, 2)' + \
-        ' - 2.0F*x_matvec_f[x][y]/pow(h_y, 2) + x_matvec_f[x][y - 1]/pow(h_y, 2)' + \
-        ' + x_matvec_f[x][y + 1]/pow(h_y, 2);'
-    
+    assert str(action_expr[-1]) == 'y_matvec_f[x][y] =' + \
+        ' -2.0F*x_matvec_f[x][y]/pow(h_x, 2) + x_matvec_f[x - 1][y]/pow(h_x, 2)' + \
+        ' + x_matvec_f[x + 1][y]/pow(h_x, 2) - 2.0F*x_matvec_f[x][y]/pow(h_y, 2)' + \
+        ' + x_matvec_f[x][y - 1]/pow(h_y, 2) + x_matvec_f[x][y + 1]/pow(h_y, 2);'
+
     assert str(rhs_expr[-1]) == 'b_tmp_f[x][y] = g[x + 2][y + 2];'
 
     # Check the iteration bounds

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -119,7 +119,7 @@ def test_petsc_solve():
 
     # Verify that the RHS expression has been shifted according to the
     # computational domain. This is necessary because the RHS of the
-    # linear system originates Devito allocated Function objects, not PETSc objects.
+    # linear system is built from Devito allocated Function objects, not PETSc objects.
     assert str(rhs_expr[-1].expr.rhs.args[0]) == 'g[x + 2, y + 2]'
 
     # Check the iteration bounds have not changed since PETSc DMDA handles


### PR DESCRIPTION
PR to track a specific type of `PETScEq` through the `Operator`. Each `PETScSolve` generates an `Action` (required by the mat-vec callback) and a `RHS` equation (to build the RHS of the linear system). Each type of `PETScEq` is linked to a specific `target` - the solution field associated with the solve - as well as specific `solver_parameters`. Each `PETScEq` variant is correlated with an IET type, facilitating its identification and subsequent placement into suitable callback functions within the `lower_petsc` pass (code for that not in this PR). 

Also, I have left the check in cluster.py to ensure the iteration bounds are correct ... I know this needs to be discussed further (but I think the rest of the PR can be reviewed). 