### PR TITLE
Init finalize

### DIFF
--- a/devito/ir/equations/equation.py
+++ b/devito/ir/equations/equation.py
@@ -11,10 +11,10 @@ from devito.symbolics import IntDiv, limits_mapper, uxreplace
 from devito.tools import Pickable, Tag, frozendict
 from devito.types import (Eq, Inc, ReduceMax, ReduceMin,
                           relational_min)
-from devito.types.equation import InjectSolveEq
+from devito.types.equation import PetscEq
 
 __all__ = ['LoweredEq', 'ClusterizedEq', 'DummyEq', 'OpInc', 'OpMin', 'OpMax',
-           'identity_mapper', 'OpInjectSolve']
+           'identity_mapper', 'OpPetsc']
 
 
 class IREq(sympy.Eq, Pickable):
@@ -105,7 +105,7 @@ class Operation(Tag):
             Inc: OpInc,
             ReduceMax: OpMax,
             ReduceMin: OpMin,
-            InjectSolveEq: OpInjectSolve
+            PetscEq: OpPetsc
         }
         try:
             return reduction_mapper[type(expr)]
@@ -122,7 +122,7 @@ class Operation(Tag):
 OpInc = Operation('+')
 OpMax = Operation('max')
 OpMin = Operation('min')
-OpInjectSolve = Operation('solve')
+OpPetsc = Operation('solve')
 
 
 identity_mapper = {

--- a/devito/ir/iet/algorithms.py
+++ b/devito/ir/iet/algorithms.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from devito.ir.iet import (Expression, Increment, Iteration, List, Conditional, SyncSpot,
                            Section, HaloSpot, ExpressionBundle)
 from devito.tools import timed_pass
-from devito.petsc.types import LinearSolveExpr
+from devito.petsc.types import MetaData
 from devito.petsc.iet.utils import petsc_iet_mapper
 
 __all__ = ['iet_build']
@@ -26,7 +26,7 @@ def iet_build(stree):
             for e in i.exprs:
                 if e.is_Increment:
                     exprs.append(Increment(e))
-                elif isinstance(e.rhs, LinearSolveExpr):
+                elif isinstance(e.rhs, MetaData):
                     exprs.append(petsc_iet_mapper[e.operation](e, operation=e.operation))
                 else:
                     exprs.append(Expression(e, operation=e.operation))

--- a/devito/petsc/iet/nodes.py
+++ b/devito/petsc/iet/nodes.py
@@ -1,20 +1,12 @@
 from devito.ir.iet import Expression, Callback, FixedArgsCallable, Call
-from devito.ir.equations import OpInjectSolve
+from devito.ir.equations import OpPetsc
 
 
-class LinearSolverExpression(Expression):
+class PetscMetaData(Expression):
     """
-    Base class for general expressions required by a
-    matrix-free linear solve of the form Ax=b.
+    Base class for general expressions required to run a PETSc solver.
     """
-    pass
-
-
-class InjectSolveDummy(LinearSolverExpression):
-    """
-    Placeholder expression to run the iterative solver.
-    """
-    def __init__(self, expr, pragmas=None, operation=OpInjectSolve):
+    def __init__(self, expr, pragmas=None, operation=OpPetsc):
         super().__init__(expr, pragmas=pragmas, operation=operation)
 
 

--- a/devito/petsc/iet/routines.py
+++ b/devito/petsc/iet/routines.py
@@ -14,7 +14,7 @@ from devito.tools import filter_ordered
 
 from devito.petsc.types import PETScArray
 from devito.petsc.iet.nodes import (PETScCallable, FormFunctionCallback,
-                                    MatVecCallback, InjectSolveDummy)
+                                    MatVecCallback, PetscMetaData)
 from devito.petsc.iet.utils import petsc_call, petsc_struct
 from devito.petsc.utils import solver_mapper
 from devito.petsc.types import (DM, CallbackDM, Mat, LocalVec, GlobalVec, KSP, PC,
@@ -768,7 +768,7 @@ class Solver:
         spatial_body = []
         for tree in retrieve_iteration_tree(iters[0]):
             root = filter_iterations(tree, key=lambda i: i.dim.is_Space)[0]
-            if injectsolve in FindNodes(InjectSolveDummy).visit(root):
+            if injectsolve in FindNodes(PetscMetaData).visit(root):
                 spatial_body.append(root)
         return spatial_body
 

--- a/devito/petsc/iet/utils.py
+++ b/devito/petsc/iet/utils.py
@@ -1,5 +1,5 @@
-from devito.petsc.iet.nodes import InjectSolveDummy, PETScCall
-from devito.ir.equations import OpInjectSolve
+from devito.petsc.iet.nodes import PetscMetaData, PETScCall
+from devito.ir.equations import OpPetsc
 
 
 def petsc_call(specific_call, call_args):
@@ -19,4 +19,4 @@ def petsc_struct(name, fields, pname, liveness='lazy'):
 
 # Mapping special Eq operations to their corresponding IET Expression subclass types.
 # These operations correspond to subclasses of Eq utilised within PETScSolve.
-petsc_iet_mapper = {OpInjectSolve: InjectSolveDummy}
+petsc_iet_mapper = {OpPetsc: PetscMetaData}

--- a/devito/petsc/initialize.py
+++ b/devito/petsc/initialize.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from ctypes import POINTER, cast, c_char
+import atexit
+
+from devito import Operator
+from devito.types import Symbol
+from devito.types.equation import PetscEq
+from devito.petsc.types import Initialize, Finalize
+
+global _petsc_initialized
+_petsc_initialized = False
+
+
+def PetscInitialize():
+    global _petsc_initialized
+    if not _petsc_initialized:
+        dummy = Symbol(name='d')
+        # TODO: Potentially just use cgen + the compiler machinery in Devito
+        # to generate these "dummy_ops" instead of using the Operator class.
+        # This would prevent circular imports when initializing during import
+        # from the PETSc module.
+        op_init = Operator(
+            [PetscEq(dummy, Initialize(dummy))],
+            name='kernel_init', opt='noop'
+        )
+        op_finalize = Operator(
+            [PetscEq(dummy, Finalize(dummy))],
+            name='kernel_finalize', opt='noop'
+        )
+
+        # `argv_bytes` must be a list so the memory address persists
+        # `os.fsencode` should be preferred over `string().encode('utf-8')`
+        # in case there is some system specific encoding in use
+        argv_bytes = list(map(os.fsencode, sys.argv))
+        argv_pointer = (POINTER(c_char)*len(sys.argv))(
+            *map(lambda s: cast(s, POINTER(c_char)), argv_bytes)
+        )
+        op_init.apply(argc=len(sys.argv), argv=argv_pointer)
+
+        atexit.register(op_finalize.apply)
+        _petsc_initialized = True

--- a/devito/petsc/solve.py
+++ b/devito/petsc/solve.py
@@ -5,7 +5,7 @@ import sympy
 from devito.finite_differences.differentiable import Mul
 from devito.finite_differences.derivative import Derivative
 from devito.types import Eq, Symbol, SteppingDimension, TimeFunction
-from devito.types.equation import InjectSolveEq
+from devito.types.equation import PetscEq
 from devito.operations.solve import eval_time_derivatives
 from devito.symbolics import retrieve_functions
 from devito.tools import as_tuple
@@ -65,7 +65,7 @@ def PETScSolve(eqns, target, solver_parameters=None, **kwargs):
     )
     # Placeholder equation for inserting calls to the solver and generating
     # correct time loop etc
-    inject_solve = InjectSolveEq(target, LinearSolveExpr(
+    inject_solve = PetscEq(target, LinearSolveExpr(
         expr=tuple(funcs),
         target=target,
         solver_parameters=solver_parameters,

--- a/devito/petsc/types/macros.py
+++ b/devito/petsc/types/macros.py
@@ -1,0 +1,5 @@
+import cgen as c
+
+
+# TODO: Don't use c.Line here?
+petsc_func_begin_user = c.Line('PetscFunctionBeginUser;')

--- a/devito/petsc/types/object.py
+++ b/devito/petsc/types/object.py
@@ -1,7 +1,8 @@
-from ctypes import POINTER
+from ctypes import POINTER, c_char
 
 from devito.tools import CustomDtype, dtype_to_cstr
 from devito.types import LocalObject, CCompositeObject, ModuloDimension, TimeDimension
+from devito.types.basic import DataSymbol
 from devito.symbolics import Byref
 
 from devito.petsc.iet.utils import petsc_call
@@ -209,3 +210,9 @@ class StartPtr(LocalObject):
     def __init__(self, name, dtype):
         super().__init__(name=name)
         self.dtype = CustomDtype(dtype_to_cstr(dtype), modifier=' *')
+
+
+class ArgvSymbol(DataSymbol):
+    @property
+    def _C_ctype(self):
+        return POINTER(POINTER(c_char))

--- a/devito/petsc/types/types.py
+++ b/devito/petsc/types/types.py
@@ -3,7 +3,27 @@ import sympy
 from devito.tools import Reconstructable, sympy_mutex
 
 
-class LinearSolveExpr(sympy.Function, Reconstructable):
+class MetaData(sympy.Function, Reconstructable):
+    def __new__(cls, expr, **kwargs):
+        with sympy_mutex:
+            obj = sympy.Function.__new__(cls, expr)
+        obj._expr = expr
+        return obj
+
+    @property
+    def expr(self):
+        return self._expr
+
+
+class Initialize(MetaData):
+    pass
+
+
+class Finalize(MetaData):
+    pass
+
+
+class LinearSolveExpr(MetaData):
     """
     A symbolic expression passed through the Operator, containing the metadata
     needed to execute a linear solver. Linear problems are handled with

--- a/devito/petsc/utils.py
+++ b/devito/petsc/utils.py
@@ -45,7 +45,7 @@ def core_metadata():
     lib_dir = os.path.join(petsc_dir, f'{petsc_arch}', 'lib')
 
     return {
-        'includes': ('petscksp.h', 'petscsnes.h', 'petscdmda.h'),
+        'includes': ('petscsnes.h', 'petscdmda.h'),
         'include_dirs': include_dirs,
         'libs': ('petsc'),
         'lib_dirs': lib_dir,

--- a/devito/types/equation.py
+++ b/devito/types/equation.py
@@ -221,5 +221,5 @@ class ReduceMin(Reduction):
     pass
 
 
-class InjectSolveEq(Eq):
+class PetscEq(Eq):
     pass

--- a/examples/petsc/init_test.py
+++ b/examples/petsc/init_test.py
@@ -1,0 +1,8 @@
+import os
+from devito.petsc.initialize import PetscInitialize
+from devito import configuration
+configuration['compiler'] = 'custom'
+os.environ['CC'] = 'mpicc'
+
+PetscInitialize()
+print("helloworld")

--- a/examples/petsc/makefile
+++ b/examples/petsc/makefile
@@ -1,0 +1,5 @@
+-include ${PETSC_DIR}/petscdir.mk
+include ${PETSC_DIR}/lib/petsc/conf/variables
+include ${PETSC_DIR}/lib/petsc/conf/rules
+
+all: test

--- a/examples/petsc/petsc_test.py
+++ b/examples/petsc/petsc_test.py
@@ -1,0 +1,29 @@
+import os
+import numpy as np
+
+from devito import (Grid, Function, Eq, Operator, configuration)
+from devito.petsc import PETScSolve
+from devito.petsc.initialize import PetscInitialize
+configuration['compiler'] = 'custom'
+os.environ['CC'] = 'mpicc'
+
+PetscInitialize()
+
+
+nx = 81
+ny = 81
+
+grid = Grid(shape=(nx, ny), extent=(2., 2.), dtype=np.float64)
+
+u = Function(name='u', grid=grid, dtype=np.float64, space_order=2)
+v = Function(name='v', grid=grid, dtype=np.float64, space_order=2)
+
+v.data[:] = 5.0
+
+eq = Eq(v, u.laplace, subdomain=grid.interior)
+
+petsc = PETScSolve([eq], u)
+
+op = Operator(petsc)
+
+op.apply()

--- a/examples/petsc/test_init.c
+++ b/examples/petsc/test_init.c
@@ -1,0 +1,26 @@
+#include <petscsys.h>
+
+extern PetscErrorCode PetscInit();
+extern PetscErrorCode PetscFinal();
+
+int main(int argc, char **argv)
+{
+  PetscInit(argc, argv);
+  PetscPrintf(PETSC_COMM_WORLD, "Hello World!\n");
+  return PetscFinalize();
+}
+
+PetscErrorCode PetscInit(int argc, char **argv)
+{
+    static char help[] = "Magic help string\n";
+    PetscFunctionBeginUser;
+    PetscCall(PetscInitialize(&argc, &argv, NULL, help));
+    PetscFunctionReturn(0);
+}
+
+PetscErrorCode PetscFinal()
+{
+    PetscFunctionBeginUser;
+    PetscCall(PetscFinalize());
+    PetscFunctionReturn(0);
+}

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -3,7 +3,8 @@ import os
 import pytest
 
 from conftest import skipif
-from devito import Grid, Function, TimeFunction, Eq, Operator, switchconfig
+from devito import (Grid, Function, TimeFunction, Eq, Operator, switchconfig,
+                    configuration)
 from devito.ir.iet import (Call, ElementalFunction, Definition, DummyExpr,
                            FindNodes, retrieve_iteration_tree)
 from devito.types import Constant, CCompositeObject
@@ -13,6 +14,16 @@ from devito.petsc.types import (DM, Mat, LocalVec, PetscMPIInt, KSP,
                                 LinearSolveExpr)
 from devito.petsc.solve import PETScSolve, separate_eqn, centre_stencil
 from devito.petsc.iet.nodes import Expression
+from devito.petsc.initialize import PetscInitialize
+
+
+@skipif('petsc')
+def test_petsc_initialization():
+    # TODO: Temporary workaround until PETSc is automatically
+    # initialized
+    configuration['compiler'] = 'custom'
+    os.environ['CC'] = 'mpicc'
+    PetscInitialize()
 
 
 @skipif('petsc')
@@ -254,14 +265,14 @@ def test_dmda_create():
         op2 = Operator(petsc2, opt='noop')
         op3 = Operator(petsc3, opt='noop')
 
-    assert 'PetscCall(DMDACreate1d(PETSC_COMM_SELF,DM_BOUNDARY_GHOSTED,' + \
+    assert 'PetscCall(DMDACreate1d(PETSC_COMM_WORLD,DM_BOUNDARY_GHOSTED,' + \
         '2,1,2,NULL,&(da_0)));' in str(op1)
 
-    assert 'PetscCall(DMDACreate2d(PETSC_COMM_SELF,DM_BOUNDARY_GHOSTED,' + \
+    assert 'PetscCall(DMDACreate2d(PETSC_COMM_WORLD,DM_BOUNDARY_GHOSTED,' + \
         'DM_BOUNDARY_GHOSTED,DMDA_STENCIL_BOX,2,2,1,1,1,4,NULL,NULL,&(da_0)));' \
         in str(op2)
 
-    assert 'PetscCall(DMDACreate3d(PETSC_COMM_SELF,DM_BOUNDARY_GHOSTED,' + \
+    assert 'PetscCall(DMDACreate3d(PETSC_COMM_WORLD,DM_BOUNDARY_GHOSTED,' + \
         'DM_BOUNDARY_GHOSTED,DM_BOUNDARY_GHOSTED,DMDA_STENCIL_BOX,6,5,4' + \
         ',1,1,1,1,6,NULL,NULL,NULL,&(da_0)));' in str(op3)
 
@@ -604,8 +615,7 @@ def test_petsc_struct():
 
 
 @skipif('petsc')
-@pytest.mark.parallel(mode=[2, 4, 8])
-def test_apply(mode):
+def test_apply():
 
     grid = Grid(shape=(13, 13), dtype=np.float64)
 
@@ -618,8 +628,7 @@ def test_apply(mode):
     petsc = PETScSolve(eqn, pn)
 
     # Build the op
-    with switchconfig(openmp=False, mpi=True):
-        op = Operator(petsc)
+    op = Operator(petsc)
 
     # Check the Operator runs without errors. Not verifying output for
     # now. Need to consolidate BC implementation


### PR DESCRIPTION
- Ensure that PetscInitialize and PetscFinalize are called only once per script, rather than for each Operator constructed.
- Support PETSc command line args

TODO:

- [x] locate mpi.h without initialising mpi
- [x] remove all switchconfigs that set the mpi variables
- [x] fix tests 