### PR TITLE
compiler: Change PETScArray type to PetscScalar

### DIFF
--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -186,7 +186,6 @@ class CGen(Visitor):
         '_mem_constant': 'static',
         '_mem_shared': '',
     }
-    _restrict_keyword = 'restrict'
 
     def _gen_struct_decl(self, obj, masked=()):
         """
@@ -259,7 +258,7 @@ class CGen(Visitor):
             strshape = ''
             if isinstance(obj, (AbstractFunction, IndexedData)) and mode >= 1:
                 if not obj._mem_stack:
-                    strtype = '%s%s' % (strtype, self._restrict_keyword)
+                    strtype = '%s%s' % (strtype, obj._restrict_keyword)
         strtype = ' '.join(qualifiers + [strtype])
 
         if obj.is_LocalType and obj._C_modifier is not None and mode == 2:

--- a/devito/petsc/types/array.py
+++ b/devito/petsc/types/array.py
@@ -6,7 +6,7 @@ from devito.types.array import ArrayBasic
 from devito.finite_differences import Differentiable
 from devito.types.basic import AbstractFunction
 from devito.finite_differences.tools import fd_weights_registry
-from devito.tools import dtype_to_ctype, as_tuple
+from devito.tools import dtype_to_ctype, as_tuple, CustomDtype
 from devito.symbolics import FieldFromComposite
 
 
@@ -106,11 +106,10 @@ class PETScArray(ArrayBasic, Differentiable):
 
     @cached_property
     def _C_ctype(self):
-        # TODO: Switch to using PetscScalar instead of float/double
         # TODO: Use cat $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables
         # | grep -E "PETSC_(SCALAR|PRECISION)" to determine the precision of
         # the user's PETSc configuration.
-        return POINTER(dtype_to_ctype(self.dtype))
+        return CustomDtype('PetscScalar', modifier= ' *')
 
     @property
     def symbolic_shape(self):
@@ -118,3 +117,7 @@ class PETScArray(ArrayBasic, Differentiable):
             FieldFromComposite('g%sm' % d.name, self.localinfo) for d in self.dimensions]
         # Reverse it since DMDA is setup backwards to Devito dimensions.
         return DimensionTuple(*field_from_composites[::-1], getters=self.dimensions)
+
+    @property
+    def _restrict_keyword(self):
+        return ''

--- a/devito/petsc/types/types.py
+++ b/devito/petsc/types/types.py
@@ -1,6 +1,9 @@
 import sympy
 
 from devito.tools import Reconstructable, sympy_mutex
+from devito.tools.dtypes_lowering import mapper
+from devito.petsc.utils import get_petsc_precision
+
 
 
 class MetaData(sympy.Function, Reconstructable):
@@ -132,6 +135,14 @@ class FieldData:
     def __init__(self, target=None, matvecs=None, formfuncs=None, formrhs=None,
                  arrays=None, **kwargs):
         self._target = kwargs.get('target', target)
+
+        petsc_precision = mapper[get_petsc_precision()]
+        if self._target.dtype != petsc_precision:
+            raise TypeError(
+                f"Your target dtype must match the precision of your "
+                f"PETSc configuration. "
+                f"Expected {petsc_precision}, but got {self._target.dtype}."
+            )
         self._matvecs = matvecs
         self._formfuncs = formfuncs
         self._formrhs = formrhs

--- a/devito/petsc/utils.py
+++ b/devito/petsc/utils.py
@@ -51,3 +51,31 @@ def core_metadata():
         'lib_dirs': lib_dir,
         'ldflags': ('-Wl,-rpath,%s' % lib_dir)
     }
+
+
+@memoized_func
+def get_petsc_variables():
+    """
+    Taken from https://www.firedrakeproject.org/_modules/firedrake/petsc.html
+
+    Get a dict of PETSc environment variables from the file:
+    $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables
+    """
+    petsc_dir = get_petsc_dir()
+    petsc_arch = get_petsc_arch()
+    variables_path = os.path.join(
+        petsc_dir, petsc_arch, 'lib', 'petsc', 'conf', 'petscvariables'
+    )
+
+    with open(variables_path) as fh:
+        # Split lines on first '=' (assignment)
+        splitlines = (line.split("=", maxsplit=1) for line in fh.readlines())
+    return {k.strip(): v.strip() for k, v in splitlines}
+
+
+def get_petsc_precision():
+    """
+    Get the PETSc precision.
+    """
+    petsc_variables = get_petsc_variables()
+    return petsc_variables['PETSC_PRECISION']

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -222,6 +222,10 @@ class CodeSymbol:
         """
         return False
 
+    @property
+    def _restrict_keyword(self):
+        return 'restrict'
+
 
 class Basic(CodeSymbol):
 


### PR DESCRIPTION
- Change the `_C_ctype` of `PetscArray` objects to `PetscScalar`
- Refactored `_restrict_keyword` to be a property of `Basic` objects, instead of a string defined in the `CGen` class. By overriding this property for `PetscArray` objects, we can prevent specific warnings generated by PETSc. 