### PR TITLE
compiler: Add PETSc language and printer

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,6 @@ from devito.arch.compiler import (compiler_registry, IntelCompiler, OneapiCompil
 from devito.ir.iet import (FindNodes, FindSymbols, Iteration, ParallelBlock,
                            retrieve_iteration_tree)
 from devito.tools import as_tuple
-from devito.petsc.utils import get_petsc_dir, get_petsc_arch
 
 try:
     from mpi4py import MPI  # noqa
@@ -95,8 +94,8 @@ def skipif(items, whole_module=False):
             skipit = "pyrevolve not installed"
             break
         if i == 'petsc':
-            petsc_dir = get_petsc_dir()
-            petsc_arch = get_petsc_arch()
+            petsc_dir = os.environ.get('PETSC_DIR')
+            petsc_arch = os.environ.get('PETSC_ARCH')
             if petsc_dir is None or petsc_arch is None:
                 skipit = "PETSC_DIR or PETSC_ARCH are not set"
                 break

--- a/conftest.py
+++ b/conftest.py
@@ -96,7 +96,7 @@ def skipif(items, whole_module=False):
             break
         if i == 'petsc':
             try:
-                petsc_dir = get_petsc_dir()
+                _ = get_petsc_dir()
             except PetscOSError:
                 skipit = "PETSc is not installed"
                 break

--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,7 @@ from devito.arch.compiler import (compiler_registry, IntelCompiler, OneapiCompil
 from devito.ir.iet import (FindNodes, FindSymbols, Iteration, ParallelBlock,
                            retrieve_iteration_tree)
 from devito.tools import as_tuple
+from devito.petsc.utils import PetscOSError, get_petsc_dir
 
 try:
     from mpi4py import MPI  # noqa
@@ -94,18 +95,11 @@ def skipif(items, whole_module=False):
             skipit = "pyrevolve not installed"
             break
         if i == 'petsc':
-            petsc_dir = os.environ.get('PETSC_DIR')
-            petsc_arch = os.environ.get('PETSC_ARCH')
-            if petsc_dir is None or petsc_arch is None:
-                skipit = "PETSC_DIR or PETSC_ARCH are not set"
+            try:
+                petsc_dir = get_petsc_dir()
+            except PetscOSError:
+                skipit = "PETSc is not installed"
                 break
-            else:
-                petsc_installed = os.path.join(
-                    petsc_dir, petsc_arch, 'include', 'petscconf.h'
-                )
-                if not os.path.isfile(petsc_installed):
-                    skipit = "PETSc is not installed"
-                    break
 
     if skipit is False:
         return pytest.mark.skipif(False, reason='')

--- a/devito/core/__init__.py
+++ b/devito/core/__init__.py
@@ -6,7 +6,8 @@ from devito.core.cpu import (
     Cpu64CustomOperator, Cpu64CustomCXXOperator,
     Cpu64CXXNoopCOperator, Cpu64CXXNoopOmpOperator,
     Cpu64AdvCXXOperator, Cpu64AdvCXXOmpOperator,
-    Cpu64FsgCXXOperator, Cpu64FsgCXXOmpOperator
+    Cpu64FsgCXXOperator, Cpu64FsgCXXOmpOperator,
+    Cpu64NoopPetscOperator, Cpu64AdvPetscOperator
 )
 from devito.core.intel import (
     Intel64AdvCOperator, Intel64AdvOmpOperator,
@@ -40,11 +41,13 @@ operator_registry.add(Cpu64NoopCOperator, Cpu64, 'noop', 'C')
 operator_registry.add(Cpu64NoopOmpOperator, Cpu64, 'noop', 'openmp')
 operator_registry.add(Cpu64CXXNoopCOperator, Cpu64, 'noop', 'CXX')
 operator_registry.add(Cpu64CXXNoopOmpOperator, Cpu64, 'noop', 'CXXopenmp')
+operator_registry.add(Cpu64NoopPetscOperator, Cpu64, 'noop', 'petsc')
 
 operator_registry.add(Cpu64AdvCOperator, Cpu64, 'advanced', 'C')
 operator_registry.add(Cpu64AdvOmpOperator, Cpu64, 'advanced', 'openmp')
 operator_registry.add(Cpu64AdvCXXOperator, Cpu64, 'advanced', 'CXX')
 operator_registry.add(Cpu64AdvCXXOmpOperator, Cpu64, 'advanced', 'CXXopenmp')
+operator_registry.add(Cpu64AdvPetscOperator, Cpu64, 'advanced', 'petsc')
 
 operator_registry.add(Cpu64FsgCOperator, Cpu64, 'advanced-fsg', 'C')
 operator_registry.add(Cpu64FsgOmpOperator, Cpu64, 'advanced-fsg', 'openmp')

--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -350,6 +350,11 @@ class Cpu64CXXNoopOmpOperator(Cpu64NoopOperator):
 class Cpu64NoopPetscOperator(Cpu64NoopOperator):
     _Target = PetscTarget
 
+    @classmethod
+    def _rcompile_wrapper(cls, **kwargs0):
+        kwargs0['language'] = 'petsc'
+        return super()._rcompile_wrapper(**kwargs0)
+
 
 class Cpu64AdvCOperator(Cpu64AdvOperator):
     _Target = CTarget
@@ -362,6 +367,11 @@ class Cpu64AdvCXXOperator(Cpu64AdvOperator):
 
 class Cpu64AdvPetscOperator(Cpu64AdvOperator):
     _Target = PetscTarget
+
+    @classmethod
+    def _rcompile_wrapper(cls, **kwargs0):
+        kwargs0['language'] = 'petsc'
+        return super()._rcompile_wrapper(**kwargs0)
 
 
 class Cpu64AdvOmpOperator(Cpu64AdvOperator):

--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -11,13 +11,14 @@ from devito.passes.clusters import (Lift, blocking, buffering, cire, cse,
 from devito.passes.iet import (CTarget, CXXTarget, COmpTarget, CXXOmpTarget,
                                avoid_denormals, linearize,
                                mpiize, hoist_prodders, relax_incr_dimensions,
-                               check_stability)
+                               check_stability, PetscTarget)
 from devito.tools import timed_pass
 
 __all__ = ['Cpu64NoopCOperator', 'Cpu64NoopOmpOperator', 'Cpu64AdvCOperator',
            'Cpu64AdvOmpOperator', 'Cpu64FsgCOperator', 'Cpu64FsgOmpOperator',
            'Cpu64CustomOperator', 'Cpu64CustomCXXOperator', 'Cpu64AdvCXXOperator',
-           'Cpu64AdvCXXOmpOperator', 'Cpu64FsgCXXOperator', 'Cpu64FsgCXXOmpOperator']
+           'Cpu64AdvCXXOmpOperator', 'Cpu64FsgCXXOperator', 'Cpu64FsgCXXOmpOperator',
+           'Cpu64NoopPetscOperator']
 
 
 class Cpu64OperatorMixin:
@@ -346,6 +347,10 @@ class Cpu64CXXNoopOmpOperator(Cpu64NoopOperator):
     LINEARIZE = True
 
 
+class Cpu64NoopPetscOperator(Cpu64NoopOperator):
+    _Target = PetscTarget
+
+
 class Cpu64AdvCOperator(Cpu64AdvOperator):
     _Target = CTarget
 
@@ -353,6 +358,10 @@ class Cpu64AdvCOperator(Cpu64AdvOperator):
 class Cpu64AdvCXXOperator(Cpu64AdvOperator):
     _Target = CXXTarget
     LINEARIZE = True
+
+
+class Cpu64AdvPetscOperator(Cpu64AdvOperator):
+    _Target = PetscTarget
 
 
 class Cpu64AdvOmpOperator(Cpu64AdvOperator):

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -155,7 +155,7 @@ class Operator(Callable):
         kwargs = parse_kwargs(**kwargs)
 
         # The Operator type for the given target
-        cls = operator_selector(**kwargs)
+        cls = operator_selector(expressions, **kwargs)
 
         # Preprocess input arguments
         kwargs = cls._normalize_kwargs(**kwargs)
@@ -1172,11 +1172,11 @@ def rcompile(expressions, kwargs, options, target=None):
     options = {**options, **rcompile_registry}
 
     if target is None:
-        cls = operator_selector(**kwargs)
+        cls = operator_selector(expressions, **kwargs)
         kwargs['options'] = options
     else:
         kwargs = parse_kwargs(**target)
-        cls = operator_selector(**kwargs)
+        cls = operator_selector(expressions, **kwargs)
         kwargs = cls._normalize_kwargs(**kwargs)
         kwargs['options'].update(options)
 

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -155,7 +155,7 @@ class Operator(Callable):
         kwargs = parse_kwargs(**kwargs)
 
         # The Operator type for the given target
-        cls = operator_selector(expressions, **kwargs)
+        cls = operator_selector(**kwargs)
 
         # Preprocess input arguments
         kwargs = cls._normalize_kwargs(**kwargs)
@@ -1172,11 +1172,11 @@ def rcompile(expressions, kwargs, options, target=None):
     options = {**options, **rcompile_registry}
 
     if target is None:
-        cls = operator_selector(expressions, **kwargs)
+        cls = operator_selector(**kwargs)
         kwargs['options'] = options
     else:
         kwargs = parse_kwargs(**target)
-        cls = operator_selector(expressions, **kwargs)
+        cls = operator_selector(**kwargs)
         kwargs = cls._normalize_kwargs(**kwargs)
         kwargs['options'].update(options)
 

--- a/devito/operator/registry.py
+++ b/devito/operator/registry.py
@@ -3,7 +3,7 @@ from itertools import product
 
 from devito.arch import Platform
 from devito.exceptions import InvalidOperator
-from devito.tools import Singleton
+from devito.tools import Singleton, as_tuple
 from devito.types.equation import PetscEq
 
 __all__ = ['operator_registry', 'operator_selector']
@@ -61,7 +61,9 @@ class OperatorRegistry(OrderedDict, metaclass=Singleton):
         """
         Infer the appropriate language based on the expressions.
         """
-        return 'petsc' if any(isinstance(eq, PetscEq) for eq in expressions) else language
+        return 'petsc' if any(
+            isinstance(eq, PetscEq) for eq in as_tuple(expressions)
+        ) else language
 
 
 operator_registry = OperatorRegistry()

--- a/devito/operator/registry.py
+++ b/devito/operator/registry.py
@@ -3,8 +3,7 @@ from itertools import product
 
 from devito.arch import Platform
 from devito.exceptions import InvalidOperator
-from devito.tools import Singleton, as_tuple
-from devito.types.equation import PetscEq
+from devito.tools import Singleton
 
 __all__ = ['operator_registry', 'operator_selector']
 
@@ -45,7 +44,6 @@ class OperatorRegistry(OrderedDict, metaclass=Singleton):
             # Optimization given as an arbitrary sequence of passes
             mode = 'custom'
 
-        language = self.infer_language(expressions, language)
         if language not in OperatorRegistry._languages:
             raise ValueError("Unknown language `%s`" % language)
 
@@ -56,14 +54,6 @@ class OperatorRegistry(OrderedDict, metaclass=Singleton):
 
         raise InvalidOperator("Cannot compile an Operator for `%s`"
                               % str((platform, mode, language)))
-
-    def infer_language(self, expressions, language='C'):
-        """
-        Infer the appropriate language based on the expressions.
-        """
-        return 'petsc' if any(
-            isinstance(eq, PetscEq) for eq in as_tuple(expressions)
-        ) else language
 
 
 operator_registry = OperatorRegistry()

--- a/devito/operator/registry.py
+++ b/devito/operator/registry.py
@@ -36,7 +36,7 @@ class OperatorRegistry(OrderedDict, metaclass=Singleton):
 
         self[(platform, mode, language)] = operator
 
-    def fetch(self, expressions, platform=None, mode=None, language='C', **kwargs):
+    def fetch(self, platform=None, mode=None, language='C', **kwargs):
         """
         Retrieve an Operator for the given `<platform, mode, language>`.
         """

--- a/devito/operator/registry.py
+++ b/devito/operator/registry.py
@@ -27,7 +27,7 @@ class OperatorRegistry(OrderedDict, metaclass=Singleton):
 
     _modes = ('noop', 'advanced', 'advanced-fsg')
     _languages = ('C', 'CXX', 'openmp', 'Copenmp', 'CXXopenmp',
-                  'openacc', 'cuda', 'hip', 'sycl')
+                  'openacc', 'cuda', 'hip', 'sycl', 'petsc')
     _accepted = _modes + tuple(product(_modes, _languages))
 
     def add(self, operator, platform, mode, language='C'):

--- a/devito/passes/iet/languages/C.py
+++ b/devito/passes/iet/languages/C.py
@@ -1,4 +1,5 @@
 import numpy as np
+import ctypes
 from sympy.printing.c import C99CodePrinter
 
 from devito.ir import Call, BasePrinter
@@ -59,3 +60,7 @@ class CPrinter(BasePrinter, C99CodePrinter):
 
 class PetscCPrinter(CPrinter):
     _restrict_keyword = ''
+
+    type_mappings = {ctypes.c_int: 'PetscInt',
+                     ctypes.c_float: 'PetscScalar',
+                     ctypes.c_double: 'PetscScalar'}

--- a/devito/passes/iet/languages/C.py
+++ b/devito/passes/iet/languages/C.py
@@ -60,7 +60,7 @@ class CPrinter(BasePrinter, C99CodePrinter):
 
 class PetscCPrinter(CPrinter):
     _restrict_keyword = ''
-    
+
     # TODO: Check to see whether Petsc is compiled with
     # 32-bit or 64-bit integers
     type_mappings = {ctypes.c_int: 'PetscInt',

--- a/devito/passes/iet/languages/C.py
+++ b/devito/passes/iet/languages/C.py
@@ -55,3 +55,7 @@ class CPrinter(BasePrinter, C99CodePrinter):
 
     def _print_ImaginaryUnit(self, expr):
         return '_Complex_I'
+
+
+class PetscCPrinter(CPrinter):
+    _restrict_keyword = ''

--- a/devito/passes/iet/languages/C.py
+++ b/devito/passes/iet/languages/C.py
@@ -1,5 +1,4 @@
 import numpy as np
-import ctypes
 from sympy.printing.c import C99CodePrinter
 
 from devito.ir import Call, BasePrinter
@@ -7,6 +6,7 @@ from devito.passes.iet.definitions import DataManager
 from devito.passes.iet.orchestration import Orchestrator
 from devito.passes.iet.langbase import LangBB
 from devito.symbolics.extended_dtypes import c_complex, c_double_complex
+from devito.petsc.utils import petsc_type_mappings
 
 __all__ = ['CBB', 'CDataManager', 'COrchestrator']
 
@@ -61,8 +61,4 @@ class CPrinter(BasePrinter, C99CodePrinter):
 class PetscCPrinter(CPrinter):
     _restrict_keyword = ''
 
-    # TODO: Check to see whether Petsc is compiled with
-    # 32-bit or 64-bit integers
-    type_mappings = {ctypes.c_int: 'PetscInt',
-                     ctypes.c_float: 'PetscScalar',
-                     ctypes.c_double: 'PetscScalar'}
+    type_mappings = {**CPrinter.type_mappings, **petsc_type_mappings}

--- a/devito/passes/iet/languages/C.py
+++ b/devito/passes/iet/languages/C.py
@@ -60,7 +60,9 @@ class CPrinter(BasePrinter, C99CodePrinter):
 
 class PetscCPrinter(CPrinter):
     _restrict_keyword = ''
-
+    
+    # TODO: Check to see whether Petsc is compiled with
+    # 32-bit or 64-bit integers
     type_mappings = {ctypes.c_int: 'PetscInt',
                      ctypes.c_float: 'PetscScalar',
                      ctypes.c_double: 'PetscScalar'}

--- a/devito/passes/iet/languages/targets.py
+++ b/devito/passes/iet/languages/targets.py
@@ -1,4 +1,5 @@
-from devito.passes.iet.languages.C import CDataManager, COrchestrator, CPrinter, PetscCPrinter
+from devito.passes.iet.languages.C import (CDataManager, COrchestrator, CPrinter,
+                                           PetscCPrinter)
 from devito.passes.iet.languages.CXX import CXXPrinter
 from devito.passes.iet.languages.openmp import (SimdOmpizer, Ompizer, DeviceOmpizer,
                                                 OmpDataManager, DeviceOmpDataManager,

--- a/devito/passes/iet/languages/targets.py
+++ b/devito/passes/iet/languages/targets.py
@@ -1,4 +1,4 @@
-from devito.passes.iet.languages.C import CDataManager, COrchestrator, CPrinter
+from devito.passes.iet.languages.C import CDataManager, COrchestrator, CPrinter, PetscCPrinter
 from devito.passes.iet.languages.CXX import CXXPrinter
 from devito.passes.iet.languages.openmp import (SimdOmpizer, Ompizer, DeviceOmpizer,
                                                 OmpDataManager, DeviceOmpDataManager,
@@ -8,7 +8,7 @@ from devito.passes.iet.languages.openacc import (DeviceAccizer, DeviceAccDataMan
 from devito.passes.iet.instrument import instrument
 
 __all__ = ['CTarget', 'OmpTarget', 'COmpTarget', 'DeviceOmpTarget', 'DeviceAccTarget',
-           'CXXTarget', 'CXXOmpTarget', 'DeviceCXXOmpTarget']
+           'CXXTarget', 'CXXOmpTarget', 'DeviceCXXOmpTarget', 'PetscTarget']
 
 
 class Target:
@@ -45,6 +45,10 @@ class COmpTarget(Target):
     DataManager = OmpDataManager
     Orchestrator = OmpOrchestrator
     Printer = CPrinter
+
+
+class PetscTarget(CTarget):
+    Printer = PetscCPrinter
 
 
 OmpTarget = COmpTarget

--- a/devito/petsc/iet/passes.py
+++ b/devito/petsc/iet/passes.py
@@ -17,7 +17,7 @@ from devito.petsc.types import (PetscMPIInt, PetscErrorCode, MultipleFieldData,
                                 SubMatrixStruct, Initialize, Finalize, ArgvSymbol)
 from devito.petsc.types.macros import petsc_func_begin_user
 from devito.petsc.iet.nodes import PetscMetaData
-from devito.petsc.utils import core_metadata
+from devito.petsc.utils import core_metadata, petsc_languages
 from devito.petsc.iet.routines import (CBBuilder, CCBBuilder, BaseObjectBuilder,
                                        CoupledObjectBuilder, BaseSetup, CoupledSetup,
                                        Solver, CoupledSolver, TimeDependent,
@@ -33,6 +33,12 @@ def lower_petsc(iet, **kwargs):
 
     if not injectsolve_mapper:
         return iet, {}
+
+    if kwargs['language'] not in petsc_languages:
+        raise ValueError(
+            f"Expected 'language' to be one of "
+            f"{petsc_languages}, but got '{kwargs['language']}'"
+        )
 
     metadata = core_metadata()
     data = FindNodes(PetscMetaData).visit(iet)

--- a/devito/petsc/initialize.py
+++ b/devito/petsc/initialize.py
@@ -3,7 +3,7 @@ import sys
 from ctypes import POINTER, cast, c_char
 import atexit
 
-from devito import Operator
+from devito import Operator, switchconfig
 from devito.types import Symbol
 from devito.types.equation import PetscEq
 from devito.petsc.types import Initialize, Finalize
@@ -20,14 +20,15 @@ def PetscInitialize():
         # to generate these "dummy_ops" instead of using the Operator class.
         # This would prevent circular imports when initializing during import
         # from the PETSc module.
-        op_init = Operator(
-            [PetscEq(dummy, Initialize(dummy))],
-            name='kernel_init', opt='noop'
-        )
-        op_finalize = Operator(
-            [PetscEq(dummy, Finalize(dummy))],
-            name='kernel_finalize', opt='noop'
-        )
+        with switchconfig(language='petsc'):
+            op_init = Operator(
+                [PetscEq(dummy, Initialize(dummy))],
+                name='kernel_init', opt='noop'
+            )
+            op_finalize = Operator(
+                [PetscEq(dummy, Finalize(dummy))],
+                name='kernel_finalize', opt='noop'
+            )
 
         # `argv_bytes` must be a list so the memory address persists
         # `os.fsencode` should be preferred over `string().encode('utf-8')`

--- a/devito/petsc/types/array.py
+++ b/devito/petsc/types/array.py
@@ -106,10 +106,6 @@ class PETScArray(ArrayBasic, Differentiable):
 
     @cached_property
     def _C_ctype(self):
-        # TODO: Switch to using PetscScalar instead of float/double
-        # TODO: Use cat $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables
-        # | grep -E "PETSC_(SCALAR|PRECISION)" to determine the precision of
-        # the user's PETSc configuration.
         return POINTER(dtype_to_ctype(self.dtype))
 
     @property

--- a/devito/petsc/types/object.py
+++ b/devito/petsc/types/object.py
@@ -188,7 +188,6 @@ class VecScatter(LocalObject):
 class StartPtr(LocalObject):
     def __init__(self, name, dtype):
         super().__init__(name=name)
-        # self.dtype = CustomDtype(dtype_to_cstr(dtype), modifier=' *')
         self.dtype = POINTER(dtype_to_ctype(dtype))
 
 

--- a/devito/petsc/types/object.py
+++ b/devito/petsc/types/object.py
@@ -1,5 +1,5 @@
 from ctypes import POINTER, c_char
-from devito.tools import CustomDtype, dtype_to_cstr, as_tuple, CustomIntType
+from devito.tools import CustomDtype, dtype_to_ctype, as_tuple, CustomIntType
 from devito.types import (LocalObject, LocalCompositeObject, ModuloDimension,
                           TimeDimension, ArrayObject, CustomDimension)
 from devito.symbolics import Byref, cast
@@ -188,7 +188,8 @@ class VecScatter(LocalObject):
 class StartPtr(LocalObject):
     def __init__(self, name, dtype):
         super().__init__(name=name)
-        self.dtype = CustomDtype(dtype_to_cstr(dtype), modifier=' *')
+        # self.dtype = CustomDtype(dtype_to_cstr(dtype), modifier=' *')
+        self.dtype = POINTER(dtype_to_ctype(dtype))
 
 
 class SingleIS(LocalObject):

--- a/devito/petsc/types/types.py
+++ b/devito/petsc/types/types.py
@@ -2,7 +2,7 @@ import sympy
 
 from devito.tools import Reconstructable, sympy_mutex
 from devito.tools.dtypes_lowering import dtype_mapper
-from devito.petsc.utils import get_petsc_precision
+from devito.petsc.utils import petsc_variables
 
 
 class MetaData(sympy.Function, Reconstructable):
@@ -135,7 +135,7 @@ class FieldData:
                  arrays=None, **kwargs):
         self._target = kwargs.get('target', target)
 
-        petsc_precision = dtype_mapper[get_petsc_precision()]
+        petsc_precision = dtype_mapper[petsc_variables['PETSC_PRECISION']]
         if self._target.dtype != petsc_precision:
             raise TypeError(
                 f"Your target dtype must match the precision of your "

--- a/devito/petsc/types/types.py
+++ b/devito/petsc/types/types.py
@@ -1,6 +1,8 @@
 import sympy
 
 from devito.tools import Reconstructable, sympy_mutex
+from devito.tools.dtypes_lowering import dtype_mapper
+from devito.petsc.utils import get_petsc_precision
 
 
 class MetaData(sympy.Function, Reconstructable):
@@ -132,6 +134,14 @@ class FieldData:
     def __init__(self, target=None, matvecs=None, formfuncs=None, formrhs=None,
                  arrays=None, **kwargs):
         self._target = kwargs.get('target', target)
+
+        petsc_precision = dtype_mapper[get_petsc_precision()]
+        if self._target.dtype != petsc_precision:
+            raise TypeError(
+                f"Your target dtype must match the precision of your "
+                f"PETSc configuration. "
+                f"Expected {petsc_precision}, but got {self._target.dtype}."
+            )
         self._matvecs = matvecs
         self._formfuncs = formfuncs
         self._formrhs = formrhs

--- a/devito/petsc/utils.py
+++ b/devito/petsc/utils.py
@@ -58,7 +58,11 @@ def get_petsc_variables():
     Get a dict of PETSc environment variables from the file:
     $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables
     """
-    petsc_dir = get_petsc_dir()
+    try:
+        petsc_dir = get_petsc_dir()
+    except PetscOSError:
+       return {}
+
     path = [petsc_dir[-1], 'lib', 'petsc', 'conf', 'petscvariables']
     variables_path = Path(*path)
 
@@ -68,10 +72,7 @@ def get_petsc_variables():
     return {k.strip(): v.strip() for k, v in splitlines}
 
 
-try:
-    petsc_variables = get_petsc_variables()
-except PetscOSError:
-    petsc_variables = {}
+petsc_variables = get_petsc_variables()
 
 # TODO: Check to see whether Petsc is compiled with
 # 32-bit or 64-bit integers

--- a/devito/petsc/utils.py
+++ b/devito/petsc/utils.py
@@ -61,15 +61,17 @@ def get_petsc_variables():
     try:
         petsc_dir = get_petsc_dir()
     except PetscOSError:
-        return {}
+        petsc_variables = {}
+    else:
+        path = [petsc_dir[-1], 'lib', 'petsc', 'conf', 'petscvariables']
+        variables_path = Path(*path)
 
-    path = [petsc_dir[-1], 'lib', 'petsc', 'conf', 'petscvariables']
-    variables_path = Path(*path)
-
-    with open(variables_path) as fh:
-        # Split lines on first '=' (assignment)
-        splitlines = (line.split("=", maxsplit=1) for line in fh.readlines())
-    return {k.strip(): v.strip() for k, v in splitlines}
+        with open(variables_path) as fh:
+            # Split lines on first '=' (assignment)
+            splitlines = (line.split("=", maxsplit=1) for line in fh.readlines())
+        petsc_variables = {k.strip(): v.strip() for k, v in splitlines}
+        
+    return petsc_variables
 
 
 petsc_variables = get_petsc_variables()

--- a/devito/petsc/utils.py
+++ b/devito/petsc/utils.py
@@ -68,7 +68,10 @@ def get_petsc_variables():
     return {k.strip(): v.strip() for k, v in splitlines}
 
 
-petsc_variables = get_petsc_variables()
+try:
+    petsc_variables = get_petsc_variables()
+except PetscOSError:
+    petsc_variables = {}
 
 # TODO: Check to see whether Petsc is compiled with
 # 32-bit or 64-bit integers

--- a/devito/petsc/utils.py
+++ b/devito/petsc/utils.py
@@ -70,7 +70,7 @@ def get_petsc_variables():
             # Split lines on first '=' (assignment)
             splitlines = (line.split("=", maxsplit=1) for line in fh.readlines())
         petsc_variables = {k.strip(): v.strip() for k, v in splitlines}
-        
+
     return petsc_variables
 
 

--- a/devito/petsc/utils.py
+++ b/devito/petsc/utils.py
@@ -61,7 +61,7 @@ def get_petsc_variables():
     try:
         petsc_dir = get_petsc_dir()
     except PetscOSError:
-       return {}
+        return {}
 
     path = [petsc_dir[-1], 'lib', 'petsc', 'conf', 'petscvariables']
     variables_path = Path(*path)

--- a/devito/petsc/utils.py
+++ b/devito/petsc/utils.py
@@ -1,5 +1,6 @@
 import os
 
+from pathlib import Path
 from devito.tools import memoized_func
 
 
@@ -51,3 +52,30 @@ def core_metadata():
         'lib_dirs': lib_dir,
         'ldflags': ('-Wl,-rpath,%s' % lib_dir)
     }
+
+
+@memoized_func
+def get_petsc_variables():
+    """
+    Taken from https://www.firedrakeproject.org/_modules/firedrake/petsc.html
+    Get a dict of PETSc environment variables from the file:
+    $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables
+    """
+    petsc_dir = get_petsc_dir()
+    petsc_arch = get_petsc_arch()
+    path = [petsc_dir, petsc_arch, 'lib', 'petsc', 'conf', 'petscvariables']
+    variables_path = Path(*path)
+
+    with open(variables_path) as fh:
+        # Split lines on first '=' (assignment)
+        splitlines = (line.split("=", maxsplit=1) for line in fh.readlines())
+    return {k.strip(): v.strip() for k, v in splitlines}
+
+
+@memoized_func
+def get_petsc_precision():
+    """
+    Get the PETSc precision.
+    """
+    petsc_variables = get_petsc_variables()
+    return petsc_variables['PETSC_PRECISION']

--- a/devito/petsc/utils.py
+++ b/devito/petsc/utils.py
@@ -4,6 +4,10 @@ from pathlib import Path
 from devito.tools import memoized_func
 
 
+class PetscOSError(OSError):
+    pass
+
+
 solver_mapper = {
     'gmres': 'KSPGMRES',
     'jacobi': 'PCJACOBI',
@@ -13,44 +17,36 @@ solver_mapper = {
 
 @memoized_func
 def get_petsc_dir():
-    # *** First try: via commonly used environment variables
-    for i in ['PETSC_DIR']:
-        petsc_dir = os.environ.get(i)
-        if petsc_dir:
-            return petsc_dir
-    # TODO: Raise error if PETSC_DIR is not set
-    return None
+    petsc_dir = os.environ.get('PETSC_DIR')
+    if petsc_dir is None:
+        raise PetscOSError("PETSC_DIR environment variable not set")
+    return petsc_dir
 
 
 @memoized_func
 def get_petsc_arch():
-    # *** First try: via commonly used environment variables
-    for i in ['PETSC_ARCH']:
-        petsc_arch = os.environ.get(i)
-        if petsc_arch:
-            return petsc_arch
-    # TODO: Raise error if PETSC_ARCH is not set
-    return None
+    # Note: users don't have to explicitly set PETSC_ARCH
+    # if they add it to the PETSC_DIR path
+    return os.environ.get('PETSC_ARCH')
 
 
+@memoized_func
 def core_metadata():
     petsc_dir = get_petsc_dir()
     petsc_arch = get_petsc_arch()
 
-    # Include directories
-    global_include = os.path.join(petsc_dir, 'include')
-    config_specific_include = os.path.join(petsc_dir, f'{petsc_arch}', 'include')
-    include_dirs = (global_include, config_specific_include)
-
-    # Lib directories
-    lib_dir = os.path.join(petsc_dir, f'{petsc_arch}', 'lib')
+    petsc_include = (os.path.join(petsc_dir, 'include'),)
+    petsc_lib = (os.path.join(petsc_dir, 'lib'),)
+    if petsc_arch:
+        petsc_include += (os.path.join(petsc_dir, petsc_arch, 'include'),)
+        petsc_lib += (os.path.join(petsc_dir, petsc_arch, 'lib'),)
 
     return {
         'includes': ('petscsnes.h', 'petscdmda.h'),
-        'include_dirs': include_dirs,
+        'include_dirs': petsc_include,
         'libs': ('petsc'),
-        'lib_dirs': lib_dir,
-        'ldflags': ('-Wl,-rpath,%s' % lib_dir)
+        'lib_dirs': petsc_lib,
+        'ldflags': tuple([f"-Wl,-rpath,{lib}" for lib in petsc_lib])
     }
 
 

--- a/devito/petsc/utils.py
+++ b/devito/petsc/utils.py
@@ -75,3 +75,6 @@ def get_petsc_precision():
     """
     petsc_variables = get_petsc_variables()
     return petsc_variables['PETSC_PRECISION']
+
+
+petsc_languages = ['petsc']

--- a/examples/petsc/petsc_test.py
+++ b/examples/petsc/petsc_test.py
@@ -1,11 +1,12 @@
 import os
 import numpy as np
 
-from devito import (Grid, Function, Eq, Operator, configuration)
+from devito import (Grid, Function, Eq, Operator, configuration, switchconfig)
 from devito.petsc import PETScSolve
 from devito.petsc.initialize import PetscInitialize
 configuration['compiler'] = 'custom'
 os.environ['CC'] = 'mpicc'
+configuration['language'] = 'petsc'
 
 PetscInitialize()
 

--- a/examples/petsc/petsc_test.py
+++ b/examples/petsc/petsc_test.py
@@ -1,12 +1,11 @@
 import os
 import numpy as np
 
-from devito import (Grid, Function, Eq, Operator, configuration)
+from devito import (Grid, Function, Eq, Operator, configuration, switchconfig)
 from devito.petsc import PETScSolve
 from devito.petsc.initialize import PetscInitialize
 configuration['compiler'] = 'custom'
 os.environ['CC'] = 'mpicc'
-configuration['language'] = 'petsc'
 
 PetscInitialize()
 
@@ -25,6 +24,6 @@ eq = Eq(v, u.laplace, subdomain=grid.interior)
 
 petsc = PETScSolve([eq], u)
 
-op = Operator(petsc)
-
-op.apply()
+with switchconfig(language='petsc'):
+    op = Operator(petsc)
+    op.apply()

--- a/examples/petsc/petsc_test.py
+++ b/examples/petsc/petsc_test.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 
-from devito import (Grid, Function, Eq, Operator, configuration, switchconfig)
+from devito import (Grid, Function, Eq, Operator, configuration)
 from devito.petsc import PETScSolve
 from devito.petsc.initialize import PetscInitialize
 configuration['compiler'] = 'custom'

--- a/examples/petsc/petsc_test.py
+++ b/examples/petsc/petsc_test.py
@@ -1,7 +1,8 @@
 import os
 import numpy as np
 
-from devito import Grid, Function, Eq, Operator, configuration
+from devito import (Grid, Function, Eq, Operator, configuration,
+                    switchconfig)
 from devito.petsc import PETScSolve
 from devito.petsc.initialize import PetscInitialize
 configuration['compiler'] = 'custom'
@@ -23,8 +24,8 @@ eq = Eq(v, u.laplace, subdomain=grid.interior)
 
 petsc = PETScSolve([eq], u)
 
-op = Operator(petsc)
-
-op.apply()
+with switchconfig(language='petsc'):
+    op = Operator(petsc)
+    op.apply()
 
 print(op.ccode)

--- a/examples/petsc/petsc_test.py
+++ b/examples/petsc/petsc_test.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 
-from devito import (Grid, Function, Eq, Operator, configuration, switchconfig)
+from devito import Grid, Function, Eq, Operator, configuration
 from devito.petsc import PETScSolve
 from devito.petsc.initialize import PetscInitialize
 configuration['compiler'] = 'custom'

--- a/examples/petsc/petsc_test.py
+++ b/examples/petsc/petsc_test.py
@@ -9,7 +9,6 @@ os.environ['CC'] = 'mpicc'
 
 PetscInitialize()
 
-
 nx = 81
 ny = 81
 
@@ -24,6 +23,8 @@ eq = Eq(v, u.laplace, subdomain=grid.interior)
 
 petsc = PETScSolve([eq], u)
 
-with switchconfig(language='petsc'):
-    op = Operator(petsc)
-    op.apply()
+op = Operator(petsc)
+
+op.apply()
+
+print(op.ccode)

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -672,7 +672,7 @@ def test_start_ptr():
 
     # Verify the case with modulo time stepping
     assert ('PetscScalar * u1_ptr0 = t1*localsize0 + '
-        '(PetscScalar*)(u1_vec->data);') in str(op1)
+            '(PetscScalar*)(u1_vec->data);') in str(op1)
 
     # Verify the case with no modulo time stepping
     u2 = TimeFunction(name='u2', grid=grid, space_order=2, save=5)
@@ -683,7 +683,7 @@ def test_start_ptr():
         op2 = Operator(petsc2)
 
     assert ('PetscScalar * u2_ptr0 = (time + 1)*localsize0 + '
-        '(PetscScalar*)(u2_vec->data);') in str(op2)
+            '(PetscScalar*)(u2_vec->data);') in str(op2)
 
 
 @skipif('petsc')

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -705,6 +705,7 @@ def test_time_loop():
 
     with switchconfig(language='petsc'):
         op1 = Operator(petsc1)
+        op1.apply(time_M=3)
     body1 = str(op1.body)
     rhs1 = str(op1._func_table['FormRHS0'].root.ccode)
 
@@ -721,6 +722,7 @@ def test_time_loop():
 
     with switchconfig(language='petsc'):
         op2 = Operator(petsc2)
+        op2.apply(time_M=3)
     body2 = str(op2.body)
     rhs2 = str(op2._func_table['FormRHS0'].root.ccode)
 
@@ -734,6 +736,7 @@ def test_time_loop():
 
     with switchconfig(language='petsc'):
         op3 = Operator(petsc3)
+        op3.apply(time_M=3)
     body3 = str(op3.body)
     rhs3 = str(op3._func_table['FormRHS0'].root.ccode)
 
@@ -751,6 +754,7 @@ def test_time_loop():
 
     with switchconfig(language='petsc'):
         op4 = Operator(petsc4 + petsc5)
+        op4.apply(time_M=3)
     body4 = str(op4.body)
 
     assert 'ctx0.t0 = t0' in body4

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -4,7 +4,7 @@ import pytest
 
 from conftest import skipif
 from devito import (Grid, Function, TimeFunction, Eq, Operator,
-                    configuration, norm, switchconfig)
+                    configuration, norm)
 from devito.ir.iet import (Call, ElementalFunction,
                            FindNodes, retrieve_iteration_tree)
 from devito.types import Constant, LocalCompositeObject
@@ -94,8 +94,7 @@ def test_petsc_solve():
 
     petsc = PETScSolve(eqn, f)
 
-    with switchconfig(language='petsc'):
-        op = Operator(petsc, opt='noop')
+    op = Operator(petsc, opt='noop')
 
     callable_roots = [meta_call.root for meta_call in op._func_table.values()]
 
@@ -148,8 +147,7 @@ def test_multiple_petsc_solves():
     petsc1 = PETScSolve(eqn1, f1)
     petsc2 = PETScSolve(eqn2, f2)
 
-    with switchconfig(language='petsc'):
-        op = Operator(petsc1+petsc2, opt='noop')
+    op = Operator(petsc1+petsc2, opt='noop')
 
     callable_roots = [meta_call.root for meta_call in op._func_table.values()]
 
@@ -178,10 +176,9 @@ def test_petsc_cast():
     petsc2 = PETScSolve(eqn2, f2)
     petsc3 = PETScSolve(eqn3, f3)
 
-    with switchconfig(language='petsc'):
-        op1 = Operator(petsc1)
-        op2 = Operator(petsc2)
-        op3 = Operator(petsc3)
+    op1 = Operator(petsc1)
+    op2 = Operator(petsc2)
+    op3 = Operator(petsc3)
 
     assert 'PetscScalar (* x_f1) = ' + \
         '(PetscScalar (*)) x_f1_vec;' in str(op1.ccode)
@@ -228,10 +225,9 @@ def test_dmda_create():
     petsc2 = PETScSolve(eqn2, f2)
     petsc3 = PETScSolve(eqn3, f3)
 
-    with switchconfig(language='petsc'):
-        op1 = Operator(petsc1, opt='noop')
-        op2 = Operator(petsc2, opt='noop')
-        op3 = Operator(petsc3, opt='noop')
+    op1 = Operator(petsc1, opt='noop')
+    op2 = Operator(petsc2, opt='noop')
+    op3 = Operator(petsc3, opt='noop')
 
     assert 'PetscCall(DMDACreate1d(PETSC_COMM_WORLD,DM_BOUNDARY_GHOSTED,' + \
         '2,1,2,NULL,&(da0)));' in str(op1)
@@ -255,8 +251,7 @@ def test_cinterface_petsc_struct():
 
     name = "foo"
 
-    with switchconfig(language='petsc'):
-        op = Operator(petsc, name=name)
+    op = Operator(petsc, name=name)
 
     # Trigger the generation of a .c and a .h files
     ccode, hcode = op.cinterface(force=True)
@@ -537,8 +532,7 @@ def test_callback_arguments():
 
     petsc1 = PETScSolve(eqn1, f1)
 
-    with switchconfig(language='petsc'):
-        op = Operator(petsc1)
+    op = Operator(petsc1)
 
     mv = op._func_table['MatMult0'].root
     ff = op._func_table['FormFunction0'].root
@@ -566,8 +560,7 @@ def test_petsc_struct():
 
     eqn2 = Eq(f1, g1*mu2)
 
-    with switchconfig(language='petsc'):
-        op = Operator([eqn2] + petsc1)
+    op = Operator([eqn2] + petsc1)
 
     arguments = op.arguments()
 
@@ -597,8 +590,7 @@ def test_apply():
     petsc = PETScSolve(eqn, pn)
 
     # Build the op
-    with switchconfig(language='petsc'):
-        op = Operator(petsc)
+    op = Operator(petsc)
 
     # Check the Operator runs without errors
     op.apply()
@@ -619,8 +611,7 @@ def test_petsc_frees():
     eqn = Eq(f.laplace, g)
     petsc = PETScSolve(eqn, f)
 
-    with switchconfig(language='petsc'):
-        op = Operator(petsc)
+    op = Operator(petsc)
 
     frees = op.body.frees
 
@@ -643,8 +634,7 @@ def test_calls_to_callbacks():
     eqn = Eq(f.laplace, g)
     petsc = PETScSolve(eqn, f)
 
-    with switchconfig(language='petsc'):
-        op = Operator(petsc)
+    op = Operator(petsc)
 
     ccode = str(op.ccode)
 
@@ -667,8 +657,7 @@ def test_start_ptr():
     eq1 = Eq(u1.dt, u1.laplace, subdomain=grid.interior)
     petsc1 = PETScSolve(eq1, u1.forward)
 
-    with switchconfig(language='petsc'):
-        op1 = Operator(petsc1)
+    op1 = Operator(petsc1)
 
     # Verify the case with modulo time stepping
     assert ('PetscScalar * u1_ptr0 = t1*localsize0 + '
@@ -679,8 +668,7 @@ def test_start_ptr():
     eq2 = Eq(u2.dt, u2.laplace, subdomain=grid.interior)
     petsc2 = PETScSolve(eq2, u2.forward)
 
-    with switchconfig(language='petsc'):
-        op2 = Operator(petsc2)
+    op2 = Operator(petsc2)
 
     assert ('PetscScalar * u2_ptr0 = (time + 1)*localsize0 + '
             '(PetscScalar*)(u2_vec->data);') in str(op2)
@@ -703,9 +691,8 @@ def test_time_loop():
     eq1 = Eq(v1.laplace, u1)
     petsc1 = PETScSolve(eq1, v1)
 
-    with switchconfig(language='petsc'):
-        op1 = Operator(petsc1)
-        op1.apply(time_M=3)
+    op1 = Operator(petsc1)
+    op1.apply(time_M=3)
     body1 = str(op1.body)
     rhs1 = str(op1._func_table['FormRHS0'].root.ccode)
 
@@ -720,9 +707,8 @@ def test_time_loop():
     eq2 = Eq(v2.laplace, u2)
     petsc2 = PETScSolve(eq2, v2)
 
-    with switchconfig(language='petsc'):
-        op2 = Operator(petsc2)
-        op2.apply(time_M=3)
+    op2 = Operator(petsc2)
+    op2.apply(time_M=3)
     body2 = str(op2.body)
     rhs2 = str(op2._func_table['FormRHS0'].root.ccode)
 
@@ -734,9 +720,8 @@ def test_time_loop():
     eq3 = Eq(v1.laplace, u1 + u1.forward)
     petsc3 = PETScSolve(eq3, v1)
 
-    with switchconfig(language='petsc'):
-        op3 = Operator(petsc3)
-        op3.apply(time_M=3)
+    op3 = Operator(petsc3)
+    op3.apply(time_M=3)
     body3 = str(op3.body)
     rhs3 = str(op3._func_table['FormRHS0'].root.ccode)
 
@@ -752,9 +737,8 @@ def test_time_loop():
     eq5 = Eq(v2.laplace, u1)
     petsc5 = PETScSolve(eq5, v2)
 
-    with switchconfig(language='petsc'):
-        op4 = Operator(petsc4 + petsc5)
-        op4.apply(time_M=3)
+    op4 = Operator(petsc4 + petsc5)
+    op4.apply(time_M=3)
     body4 = str(op4.body)
 
     assert 'ctx0.t0 = t0' in body4
@@ -777,10 +761,9 @@ def test_solve_output():
     eqn = Eq(u, v)
     petsc = PETScSolve(eqn, target=u)
 
-    with switchconfig(language='petsc'):
-        op = Operator(petsc)
-        # Check the solve function returns the correct output
-        op.apply()
+    op = Operator(petsc)
+    # Check the solve function returns the correct output
+    op.apply()
 
     assert np.allclose(u.data, v.data)
 
@@ -811,9 +794,8 @@ class TestCoupledLinear:
         petsc1 = PETScSolve(eq1, target=e)
         petsc2 = PETScSolve(eq2, target=g)
 
-        with switchconfig(language='petsc'):
-            op1 = Operator(petsc1 + petsc2, opt='noop')
-            op1.apply()
+        op1 = Operator(petsc1 + petsc2, opt='noop')
+        op1.apply()
 
         enorm1 = norm(e)
         gnorm1 = norm(g)
@@ -827,9 +809,8 @@ class TestCoupledLinear:
         # using a dict for now
         petsc3 = PETScSolve({e: [eq1], g: [eq2]})
 
-        with switchconfig(language='petsc'):
-            op2 = Operator(petsc3, opt='noop')
-            op2.apply()
+        op2 = Operator(petsc3, opt='noop')
+        op2.apply()
 
         enorm2 = norm(e)
         gnorm2 = norm(g)
@@ -871,8 +852,7 @@ class TestCoupledLinear:
 
         name = "foo"
 
-        with switchconfig(language='petsc'):
-            op = Operator(petsc, name=name)
+        op = Operator(petsc, name=name)
 
         # Trigger the generation of a .c and a .h files
         ccode, hcode = op.cinterface(force=True)
@@ -913,9 +893,8 @@ class TestCoupledLinear:
         petsc1 = PETScSolve({e: [eq1], f: [eq2]})
         petsc2 = PETScSolve({e: [eq1], f: [eq2], g: [eq3]})
 
-        with switchconfig(language='petsc'):
-            op1 = Operator(petsc1, opt='noop')
-            op2 = Operator(petsc2, opt='noop')
+        op1 = Operator(petsc1, opt='noop')
+        op2 = Operator(petsc2, opt='noop')
 
         frees1 = op1.body.frees
         frees2 = op2.body.frees
@@ -958,10 +937,9 @@ class TestCoupledLinear:
         petsc2 = PETScSolve({e: [eq1], f: [eq2]})
         petsc3 = PETScSolve({e: [eq1], f: [eq2], g: [eq3]})
 
-        with switchconfig(language='petsc'):
-            op1 = Operator(petsc1, opt='noop')
-            op2 = Operator(petsc2, opt='noop')
-            op3 = Operator(petsc3, opt='noop')
+        op1 = Operator(petsc1, opt='noop')
+        op2 = Operator(petsc2, opt='noop')
+        op3 = Operator(petsc3, opt='noop')
 
         # Check the number of dofs in the DMDA for each field
         assert 'PetscCall(DMDACreate2d(PETSC_COMM_WORLD,DM_BOUNDARY_GHOSTED,' + \

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -4,7 +4,7 @@ import pytest
 
 from conftest import skipif
 from devito import (Grid, Function, TimeFunction, Eq, Operator,
-                    configuration, norm)
+                    configuration, norm, switchconfig)
 from devito.ir.iet import (Call, ElementalFunction,
                            FindNodes, retrieve_iteration_tree)
 from devito.types import Constant, LocalCompositeObject
@@ -22,7 +22,6 @@ def test_petsc_initialization():
     # TODO: Temporary workaround until PETSc is automatically
     # initialized
     configuration['compiler'] = 'custom'
-    configuration['language'] = 'petsc'
     os.environ['CC'] = 'mpicc'
     PetscInitialize()
 
@@ -95,7 +94,8 @@ def test_petsc_solve():
 
     petsc = PETScSolve(eqn, f)
 
-    op = Operator(petsc, opt='noop')
+    with switchconfig(language='petsc'):
+        op = Operator(petsc, opt='noop')
 
     callable_roots = [meta_call.root for meta_call in op._func_table.values()]
 
@@ -148,7 +148,8 @@ def test_multiple_petsc_solves():
     petsc1 = PETScSolve(eqn1, f1)
     petsc2 = PETScSolve(eqn2, f2)
 
-    op = Operator(petsc1+petsc2, opt='noop')
+    with switchconfig(language='petsc'):
+        op = Operator(petsc1+petsc2, opt='noop')
 
     callable_roots = [meta_call.root for meta_call in op._func_table.values()]
 
@@ -177,9 +178,10 @@ def test_petsc_cast():
     petsc2 = PETScSolve(eqn2, f2)
     petsc3 = PETScSolve(eqn3, f3)
 
-    op1 = Operator(petsc1)
-    op2 = Operator(petsc2)
-    op3 = Operator(petsc3)
+    with switchconfig(language='petsc'):
+        op1 = Operator(petsc1)
+        op2 = Operator(petsc2)
+        op3 = Operator(petsc3)
 
     assert 'PetscScalar (* x_f1) = ' + \
         '(PetscScalar (*)) x_f1_vec;' in str(op1.ccode)
@@ -226,9 +228,10 @@ def test_dmda_create():
     petsc2 = PETScSolve(eqn2, f2)
     petsc3 = PETScSolve(eqn3, f3)
 
-    op1 = Operator(petsc1, opt='noop')
-    op2 = Operator(petsc2, opt='noop')
-    op3 = Operator(petsc3, opt='noop')
+    with switchconfig(language='petsc'):
+        op1 = Operator(petsc1, opt='noop')
+        op2 = Operator(petsc2, opt='noop')
+        op3 = Operator(petsc3, opt='noop')
 
     assert 'PetscCall(DMDACreate1d(PETSC_COMM_WORLD,DM_BOUNDARY_GHOSTED,' + \
         '2,1,2,NULL,&(da0)));' in str(op1)
@@ -252,7 +255,8 @@ def test_cinterface_petsc_struct():
 
     name = "foo"
 
-    op = Operator(petsc, name=name)
+    with switchconfig(language='petsc'):
+        op = Operator(petsc, name=name)
 
     # Trigger the generation of a .c and a .h files
     ccode, hcode = op.cinterface(force=True)
@@ -533,7 +537,8 @@ def test_callback_arguments():
 
     petsc1 = PETScSolve(eqn1, f1)
 
-    op = Operator(petsc1)
+    with switchconfig(language='petsc'):
+        op = Operator(petsc1)
 
     mv = op._func_table['MatMult0'].root
     ff = op._func_table['FormFunction0'].root
@@ -561,7 +566,8 @@ def test_petsc_struct():
 
     eqn2 = Eq(f1, g1*mu2)
 
-    op = Operator([eqn2] + petsc1)
+    with switchconfig(language='petsc'):
+        op = Operator([eqn2] + petsc1)
 
     arguments = op.arguments()
 
@@ -591,7 +597,8 @@ def test_apply():
     petsc = PETScSolve(eqn, pn)
 
     # Build the op
-    op = Operator(petsc)
+    with switchconfig(language='petsc'):
+        op = Operator(petsc)
 
     # Check the Operator runs without errors
     op.apply()
@@ -612,7 +619,8 @@ def test_petsc_frees():
     eqn = Eq(f.laplace, g)
     petsc = PETScSolve(eqn, f)
 
-    op = Operator(petsc)
+    with switchconfig(language='petsc'):
+        op = Operator(petsc)
 
     frees = op.body.frees
 
@@ -635,7 +643,8 @@ def test_calls_to_callbacks():
     eqn = Eq(f.laplace, g)
     petsc = PETScSolve(eqn, f)
 
-    op = Operator(petsc)
+    with switchconfig(language='petsc'):
+        op = Operator(petsc)
 
     ccode = str(op.ccode)
 
@@ -658,7 +667,8 @@ def test_start_ptr():
     eq1 = Eq(u1.dt, u1.laplace, subdomain=grid.interior)
     petsc1 = PETScSolve(eq1, u1.forward)
 
-    op1 = Operator(petsc1)
+    with switchconfig(language='petsc'):
+        op1 = Operator(petsc1)
 
     # Verify the case with modulo time stepping
     assert 'PetscScalar * u1_ptr0 = t1*localsize0 + (PetscScalar*)(u1_vec->data);' in str(op1)
@@ -668,7 +678,8 @@ def test_start_ptr():
     eq2 = Eq(u2.dt, u2.laplace, subdomain=grid.interior)
     petsc2 = PETScSolve(eq2, u2.forward)
 
-    op2 = Operator(petsc2)
+    with switchconfig(language='petsc'):
+        op2 = Operator(petsc2)
 
     assert 'PetscScalar * u2_ptr0 = (time + 1)*localsize0 + ' + \
         '(PetscScalar*)(u2_vec->data);' in str(op2)
@@ -691,7 +702,8 @@ def test_time_loop():
     eq1 = Eq(v1.laplace, u1)
     petsc1 = PETScSolve(eq1, v1)
 
-    op1 = Operator(petsc1)
+    with switchconfig(language='petsc'):
+        op1 = Operator(petsc1)
     body1 = str(op1.body)
     rhs1 = str(op1._func_table['FormRHS0'].root.ccode)
 
@@ -706,7 +718,8 @@ def test_time_loop():
     eq2 = Eq(v2.laplace, u2)
     petsc2 = PETScSolve(eq2, v2)
 
-    op2 = Operator(petsc2)
+    with switchconfig(language='petsc'):
+        op2 = Operator(petsc2)
     body2 = str(op2.body)
     rhs2 = str(op2._func_table['FormRHS0'].root.ccode)
 
@@ -718,7 +731,8 @@ def test_time_loop():
     eq3 = Eq(v1.laplace, u1 + u1.forward)
     petsc3 = PETScSolve(eq3, v1)
 
-    op3 = Operator(petsc3)
+    with switchconfig(language='petsc'):
+        op3 = Operator(petsc3)
     body3 = str(op3.body)
     rhs3 = str(op3._func_table['FormRHS0'].root.ccode)
 
@@ -734,7 +748,8 @@ def test_time_loop():
     eq5 = Eq(v2.laplace, u1)
     petsc5 = PETScSolve(eq5, v2)
 
-    op4 = Operator(petsc4 + petsc5)
+    with switchconfig(language='petsc'):
+        op4 = Operator(petsc4 + petsc5)
     body4 = str(op4.body)
 
     assert 'ctx0.t0 = t0' in body4
@@ -757,7 +772,8 @@ def test_solve_output():
     eqn = Eq(u, v)
     petsc = PETScSolve(eqn, target=u)
 
-    op = Operator(petsc)
+    with switchconfig(language='petsc'):
+        op = Operator(petsc)
     # Check the solve function returns the correct output
     op.apply()
 
@@ -790,8 +806,9 @@ class TestCoupledLinear:
         petsc1 = PETScSolve(eq1, target=e)
         petsc2 = PETScSolve(eq2, target=g)
 
-        op1 = Operator(petsc1 + petsc2, opt='noop')
-        op1.apply()
+        with switchconfig(language='petsc'):
+            op1 = Operator(petsc1 + petsc2, opt='noop')
+            op1.apply()
 
         enorm1 = norm(e)
         gnorm1 = norm(g)
@@ -805,8 +822,9 @@ class TestCoupledLinear:
         # using a dict for now
         petsc3 = PETScSolve({e: [eq1], g: [eq2]})
 
-        op2 = Operator(petsc3, opt='noop')
-        op2.apply()
+        with switchconfig(language='petsc'):
+            op2 = Operator(petsc3, opt='noop')
+            op2.apply()
 
         enorm2 = norm(e)
         gnorm2 = norm(g)
@@ -848,7 +866,8 @@ class TestCoupledLinear:
 
         name = "foo"
 
-        op = Operator(petsc, name=name)
+        with switchconfig(language='petsc'):
+            op = Operator(petsc, name=name)
 
         # Trigger the generation of a .c and a .h files
         ccode, hcode = op.cinterface(force=True)
@@ -889,8 +908,9 @@ class TestCoupledLinear:
         petsc1 = PETScSolve({e: [eq1], f: [eq2]})
         petsc2 = PETScSolve({e: [eq1], f: [eq2], g: [eq3]})
 
-        op1 = Operator(petsc1, opt='noop')
-        op2 = Operator(petsc2, opt='noop')
+        with switchconfig(language='petsc'):
+            op1 = Operator(petsc1, opt='noop')
+            op2 = Operator(petsc2, opt='noop')
 
         frees1 = op1.body.frees
         frees2 = op2.body.frees
@@ -933,9 +953,10 @@ class TestCoupledLinear:
         petsc2 = PETScSolve({e: [eq1], f: [eq2]})
         petsc3 = PETScSolve({e: [eq1], f: [eq2], g: [eq3]})
 
-        op1 = Operator(petsc1, opt='noop')
-        op2 = Operator(petsc2, opt='noop')
-        op3 = Operator(petsc3, opt='noop')
+        with switchconfig(language='petsc'):
+            op1 = Operator(petsc1, opt='noop')
+            op2 = Operator(petsc2, opt='noop')
+            op3 = Operator(petsc3, opt='noop')
 
         # Check the number of dofs in the DMDA for each field
         assert 'PetscCall(DMDACreate2d(PETSC_COMM_WORLD,DM_BOUNDARY_GHOSTED,' + \

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -775,8 +775,8 @@ def test_solve_output():
 
     with switchconfig(language='petsc'):
         op = Operator(petsc)
-    # Check the solve function returns the correct output
-    op.apply()
+        # Check the solve function returns the correct output
+        op.apply()
 
     assert np.allclose(u.data, v.data)
 

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -181,12 +181,12 @@ def test_petsc_cast():
     op2 = Operator(petsc2)
     op3 = Operator(petsc3)
 
-    assert 'double (* x_f1) = ' + \
-        '(double (*)) x_f1_vec;' in str(op1.ccode)
-    assert 'double (* x_f2)[info.gxm] = ' + \
-        '(double (*)[info.gxm]) x_f2_vec;' in str(op2.ccode)
-    assert 'double (* x_f3)[info.gym][info.gxm] = ' + \
-        '(double (*)[info.gym][info.gxm]) x_f3_vec;' in str(op3.ccode)
+    assert 'PetscScalar (* x_f1) = ' + \
+        '(PetscScalar (*)) x_f1_vec;' in str(op1.ccode)
+    assert 'PetscScalar (* x_f2)[info.gxm] = ' + \
+        '(PetscScalar (*)[info.gxm]) x_f2_vec;' in str(op2.ccode)
+    assert 'PetscScalar (* x_f3)[info.gym][info.gxm] = ' + \
+        '(PetscScalar (*)[info.gym][info.gxm]) x_f3_vec;' in str(op3.ccode)
 
 
 @skipif('petsc')
@@ -661,7 +661,7 @@ def test_start_ptr():
     op1 = Operator(petsc1)
 
     # Verify the case with modulo time stepping
-    assert 'double * u1_ptr0 = t1*localsize0 + (double*)(u1_vec->data);' in str(op1)
+    assert 'PetscScalar * u1_ptr0 = t1*localsize0 + (PetscScalar*)(u1_vec->data);' in str(op1)
 
     # Verify the case with no modulo time stepping
     u2 = TimeFunction(name='u2', grid=grid, space_order=2, save=5)
@@ -670,8 +670,8 @@ def test_start_ptr():
 
     op2 = Operator(petsc2)
 
-    assert 'double * u2_ptr0 = (time + 1)*localsize0 + ' + \
-        '(double*)(u2_vec->data);' in str(op2)
+    assert 'PetscScalar * u2_ptr0 = (time + 1)*localsize0 + ' + \
+        '(PetscScalar*)(u2_vec->data);' in str(op2)
 
 
 @skipif('petsc')

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -3,9 +3,9 @@ import os
 import pytest
 
 from conftest import skipif
-from devito import (Grid, Function, TimeFunction, Eq, Operator, switchconfig,
+from devito import (Grid, Function, TimeFunction, Eq, Operator,
                     configuration, norm)
-from devito.ir.iet import (Call, ElementalFunction, Definition, DummyExpr,
+from devito.ir.iet import (Call, ElementalFunction,
                            FindNodes, retrieve_iteration_tree)
 from devito.types import Constant, LocalCompositeObject
 from devito.passes.iet.languages.C import CDataManager

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -22,6 +22,7 @@ def test_petsc_initialization():
     # TODO: Temporary workaround until PETSc is automatically
     # initialized
     configuration['compiler'] = 'custom'
+    configuration['language'] = 'petsc'
     os.environ['CC'] = 'mpicc'
     PetscInitialize()
 
@@ -55,33 +56,6 @@ def test_petsc_local_object():
 
 
 @skipif('petsc')
-def test_petsc_functions():
-    """
-    Test C++ support for PETScArrays.
-    """
-    grid = Grid((2, 2))
-    x, y = grid.dimensions
-
-    f0 = Function(name='f', grid=grid, space_order=2, dtype=np.float32)
-    f1 = Function(name='f', grid=grid, space_order=2, dtype=np.float64)
-
-    ptr0 = PETScArray(name='ptr0', target=f0)
-    ptr1 = PETScArray(name='ptr1', target=f0, is_const=True)
-    ptr2 = PETScArray(name='ptr2', target=f1, is_const=True)
-
-    defn0 = Definition(ptr0)
-    defn1 = Definition(ptr1)
-    defn2 = Definition(ptr2)
-
-    expr = DummyExpr(ptr0.indexed[x, y], ptr1.indexed[x, y] + 1)
-
-    assert str(defn0) == 'float *restrict ptr0_vec;'
-    assert str(defn1) == 'const float *restrict ptr1_vec;'
-    assert str(defn2) == 'const double *restrict ptr2_vec;'
-    assert str(expr) == 'ptr0[x][y] = ptr1[x][y] + 1;'
-
-
-@skipif('petsc')
 def test_petsc_subs():
     """
     Test support for PETScArrays in substitutions.
@@ -112,7 +86,7 @@ def test_petsc_solve():
     """
     Test PETScSolve.
     """
-    grid = Grid((2, 2))
+    grid = Grid((2, 2), dtype=np.float64)
 
     f = Function(name='f', grid=grid, space_order=2)
     g = Function(name='g', grid=grid, space_order=2)
@@ -121,8 +95,7 @@ def test_petsc_solve():
 
     petsc = PETScSolve(eqn, f)
 
-    with switchconfig(openmp=False):
-        op = Operator(petsc, opt='noop')
+    op = Operator(petsc, opt='noop')
 
     callable_roots = [meta_call.root for meta_call in op._func_table.values()]
 
@@ -161,7 +134,7 @@ def test_multiple_petsc_solves():
     """
     Test multiple PETScSolves.
     """
-    grid = Grid((2, 2))
+    grid = Grid((2, 2), dtype=np.float64)
 
     f1 = Function(name='f1', grid=grid, space_order=2)
     g1 = Function(name='g1', grid=grid, space_order=2)
@@ -175,8 +148,7 @@ def test_multiple_petsc_solves():
     petsc1 = PETScSolve(eqn1, f1)
     petsc2 = PETScSolve(eqn2, f2)
 
-    with switchconfig(openmp=False):
-        op = Operator(petsc1+petsc2, opt='noop')
+    op = Operator(petsc1+petsc2, opt='noop')
 
     callable_roots = [meta_call.root for meta_call in op._func_table.values()]
 
@@ -189,9 +161,9 @@ def test_petsc_cast():
     """
     Test casting of PETScArray.
     """
-    grid1 = Grid((2))
-    grid2 = Grid((2, 2))
-    grid3 = Grid((4, 5, 6))
+    grid1 = Grid((2), dtype=np.float64)
+    grid2 = Grid((2, 2), dtype=np.float64)
+    grid3 = Grid((4, 5, 6), dtype=np.float64)
 
     f1 = Function(name='f1', grid=grid1, space_order=2)
     f2 = Function(name='f2', grid=grid2, space_order=4)
@@ -205,37 +177,29 @@ def test_petsc_cast():
     petsc2 = PETScSolve(eqn2, f2)
     petsc3 = PETScSolve(eqn3, f3)
 
-    with switchconfig(openmp=False):
-        op1 = Operator(petsc1, opt='noop')
-        op2 = Operator(petsc2, opt='noop')
-        op3 = Operator(petsc3, opt='noop')
+    op1 = Operator(petsc1)
+    op2 = Operator(petsc2)
+    op3 = Operator(petsc3)
 
-    cb1 = [meta_call.root for meta_call in op1._func_table.values()]
-    cb2 = [meta_call.root for meta_call in op2._func_table.values()]
-    cb3 = [meta_call.root for meta_call in op3._func_table.values()]
-
-    assert 'float (*restrict x_f1) = ' + \
-        '(float (*)) x_f1_vec;' in str(cb1[0])
-    assert 'float (*restrict x_f2)[info.gxm] = ' + \
-        '(float (*)[info.gxm]) x_f2_vec;' in str(cb2[0])
-    assert 'float (*restrict x_f3)[info.gym][info.gxm] = ' + \
-        '(float (*)[info.gym][info.gxm]) x_f3_vec;' in str(cb3[0])
+    assert 'double (* x_f1) = ' + \
+        '(double (*)) x_f1_vec;' in str(op1.ccode)
+    assert 'double (* x_f2)[info.gxm] = ' + \
+        '(double (*)[info.gxm]) x_f2_vec;' in str(op2.ccode)
+    assert 'double (* x_f3)[info.gym][info.gxm] = ' + \
+        '(double (*)[info.gym][info.gxm]) x_f3_vec;' in str(op3.ccode)
 
 
 @skipif('petsc')
 def test_LinearSolveExpr():
 
-    grid = Grid((2, 2))
+    grid = Grid((2, 2), dtype=np.float64)
 
     f = Function(name='f', grid=grid, space_order=2)
     g = Function(name='g', grid=grid, space_order=2)
 
     eqn = Eq(f, g.laplace)
 
-    linsolveexpr = LinearSolveExpr(eqn.rhs, target=f)
-
-    # TODO: maybe expand this test now to check the fielddata etc
-    linsolveexpr = LinearSolveExpr(eqn.rhs)
+    linsolveexpr = LinearSolveExpr(eqn.rhs, fielddata=FieldData(target=f))
 
     # Check the solver parameters
     assert linsolveexpr.solver_parameters == \
@@ -246,9 +210,9 @@ def test_LinearSolveExpr():
 @skipif('petsc')
 def test_dmda_create():
 
-    grid1 = Grid((2))
-    grid2 = Grid((2, 2))
-    grid3 = Grid((4, 5, 6))
+    grid1 = Grid((2), dtype=np.float64)
+    grid2 = Grid((2, 2), dtype=np.float64)
+    grid3 = Grid((4, 5, 6), dtype=np.float64)
 
     f1 = Function(name='f1', grid=grid1, space_order=2)
     f2 = Function(name='f2', grid=grid2, space_order=4)
@@ -262,10 +226,9 @@ def test_dmda_create():
     petsc2 = PETScSolve(eqn2, f2)
     petsc3 = PETScSolve(eqn3, f3)
 
-    with switchconfig(openmp=False):
-        op1 = Operator(petsc1, opt='noop')
-        op2 = Operator(petsc2, opt='noop')
-        op3 = Operator(petsc3, opt='noop')
+    op1 = Operator(petsc1, opt='noop')
+    op2 = Operator(petsc2, opt='noop')
+    op3 = Operator(petsc3, opt='noop')
 
     assert 'PetscCall(DMDACreate1d(PETSC_COMM_WORLD,DM_BOUNDARY_GHOSTED,' + \
         '2,1,2,NULL,&(da0)));' in str(op1)
@@ -282,14 +245,14 @@ def test_dmda_create():
 @skipif('petsc')
 def test_cinterface_petsc_struct():
 
-    grid = Grid(shape=(11, 11))
+    grid = Grid(shape=(11, 11), dtype=np.float64)
     f = Function(name='f', grid=grid, space_order=2)
     eq = Eq(f.laplace, 10)
     petsc = PETScSolve(eq, f)
 
     name = "foo"
-    with switchconfig(openmp=False):
-        op = Operator(petsc, name=name)
+
+    op = Operator(petsc, name=name)
 
     # Trigger the generation of a .c and a .h files
     ccode, hcode = op.cinterface(force=True)
@@ -561,7 +524,7 @@ def test_callback_arguments():
     """
     Test the arguments of each callback function.
     """
-    grid = Grid((2, 2))
+    grid = Grid((2, 2), dtype=np.float64)
 
     f1 = Function(name='f1', grid=grid, space_order=2)
     g1 = Function(name='g1', grid=grid, space_order=2)
@@ -570,8 +533,7 @@ def test_callback_arguments():
 
     petsc1 = PETScSolve(eqn1, f1)
 
-    with switchconfig(openmp=False):
-        op = Operator(petsc1)
+    op = Operator(petsc1)
 
     mv = op._func_table['MatMult0'].root
     ff = op._func_table['FormFunction0'].root
@@ -586,7 +548,7 @@ def test_callback_arguments():
 @skipif('petsc')
 def test_petsc_struct():
 
-    grid = Grid((2, 2))
+    grid = Grid((2, 2), dtype=np.float64)
 
     f1 = Function(name='f1', grid=grid, space_order=2)
     g1 = Function(name='g1', grid=grid, space_order=2)
@@ -599,8 +561,7 @@ def test_petsc_struct():
 
     eqn2 = Eq(f1, g1*mu2)
 
-    with switchconfig(openmp=False):
-        op = Operator([eqn2] + petsc1)
+    op = Operator([eqn2] + petsc1)
 
     arguments = op.arguments()
 
@@ -621,8 +582,8 @@ def test_apply():
 
     grid = Grid(shape=(13, 13), dtype=np.float64)
 
-    pn = Function(name='pn', grid=grid, space_order=2, dtype=np.float64)
-    rhs = Function(name='rhs', grid=grid, space_order=2, dtype=np.float64)
+    pn = Function(name='pn', grid=grid, space_order=2)
+    rhs = Function(name='rhs', grid=grid, space_order=2)
     mu = Constant(name='mu', value=2.0)
 
     eqn = Eq(pn.laplace*mu, rhs, subdomain=grid.interior)
@@ -643,7 +604,7 @@ def test_apply():
 @skipif('petsc')
 def test_petsc_frees():
 
-    grid = Grid((2, 2))
+    grid = Grid((2, 2), dtype=np.float64)
 
     f = Function(name='f', grid=grid, space_order=2)
     g = Function(name='g', grid=grid, space_order=2)
@@ -651,8 +612,7 @@ def test_petsc_frees():
     eqn = Eq(f.laplace, g)
     petsc = PETScSolve(eqn, f)
 
-    with switchconfig(openmp=False):
-        op = Operator(petsc)
+    op = Operator(petsc)
 
     frees = op.body.frees
 
@@ -667,7 +627,7 @@ def test_petsc_frees():
 @skipif('petsc')
 def test_calls_to_callbacks():
 
-    grid = Grid((2, 2))
+    grid = Grid((2, 2), dtype=np.float64)
 
     f = Function(name='f', grid=grid, space_order=2)
     g = Function(name='g', grid=grid, space_order=2)
@@ -675,8 +635,7 @@ def test_calls_to_callbacks():
     eqn = Eq(f.laplace, g)
     petsc = PETScSolve(eqn, f)
 
-    with switchconfig(openmp=False):
-        op = Operator(petsc)
+    op = Operator(petsc)
 
     ccode = str(op.ccode)
 
@@ -694,27 +653,25 @@ def test_start_ptr():
     This functionality is crucial for VecReplaceArray operations, as it ensures
     that the correct memory location is accessed and modified during each time step.
     """
-    grid = Grid((11, 11))
-    u1 = TimeFunction(name='u1', grid=grid, space_order=2, dtype=np.float32)
+    grid = Grid((11, 11), dtype=np.float64)
+    u1 = TimeFunction(name='u1', grid=grid, space_order=2)
     eq1 = Eq(u1.dt, u1.laplace, subdomain=grid.interior)
     petsc1 = PETScSolve(eq1, u1.forward)
 
-    with switchconfig(openmp=False):
-        op1 = Operator(petsc1)
+    op1 = Operator(petsc1)
 
     # Verify the case with modulo time stepping
-    assert 'float * u1_ptr0 = t1*localsize0 + (float*)(u1_vec->data);' in str(op1)
+    assert 'double * u1_ptr0 = t1*localsize0 + (double*)(u1_vec->data);' in str(op1)
 
     # Verify the case with no modulo time stepping
-    u2 = TimeFunction(name='u2', grid=grid, space_order=2, dtype=np.float32, save=5)
+    u2 = TimeFunction(name='u2', grid=grid, space_order=2, save=5)
     eq2 = Eq(u2.dt, u2.laplace, subdomain=grid.interior)
     petsc2 = PETScSolve(eq2, u2.forward)
 
-    with switchconfig(openmp=False):
-        op2 = Operator(petsc2)
+    op2 = Operator(petsc2)
 
-    assert 'float * u2_ptr0 = (time + 1)*localsize0 + ' + \
-        '(float*)(u2_vec->data);' in str(op2)
+    assert 'double * u2_ptr0 = (time + 1)*localsize0 + ' + \
+        '(double*)(u2_vec->data);' in str(op2)
 
 
 @skipif('petsc')
@@ -726,15 +683,15 @@ def test_time_loop():
     - Only assign/update the modulo dimensions required by any of the
     PETSc callback functions.
     """
-    grid = Grid((11, 11))
+    grid = Grid((11, 11), dtype=np.float64)
 
     # Modulo time stepping
     u1 = TimeFunction(name='u1', grid=grid, space_order=2)
     v1 = Function(name='v1', grid=grid, space_order=2)
     eq1 = Eq(v1.laplace, u1)
     petsc1 = PETScSolve(eq1, v1)
-    with switchconfig(openmp=False):
-        op1 = Operator(petsc1)
+
+    op1 = Operator(petsc1)
     body1 = str(op1.body)
     rhs1 = str(op1._func_table['FormRHS0'].root.ccode)
 
@@ -748,8 +705,8 @@ def test_time_loop():
     v2 = Function(name='v2', grid=grid, space_order=2, save=5)
     eq2 = Eq(v2.laplace, u2)
     petsc2 = PETScSolve(eq2, v2)
-    with switchconfig(openmp=False):
-        op2 = Operator(petsc2)
+
+    op2 = Operator(petsc2)
     body2 = str(op2.body)
     rhs2 = str(op2._func_table['FormRHS0'].root.ccode)
 
@@ -760,8 +717,8 @@ def test_time_loop():
     # used in one of the callback functions
     eq3 = Eq(v1.laplace, u1 + u1.forward)
     petsc3 = PETScSolve(eq3, v1)
-    with switchconfig(openmp=False):
-        op3 = Operator(petsc3)
+
+    op3 = Operator(petsc3)
     body3 = str(op3.body)
     rhs3 = str(op3._func_table['FormRHS0'].root.ccode)
 
@@ -776,12 +733,35 @@ def test_time_loop():
     petsc4 = PETScSolve(eq4, v1)
     eq5 = Eq(v2.laplace, u1)
     petsc5 = PETScSolve(eq5, v2)
-    with switchconfig(openmp=False):
-        op4 = Operator(petsc4 + petsc5)
+
+    op4 = Operator(petsc4 + petsc5)
     body4 = str(op4.body)
 
     assert 'ctx0.t0 = t0' in body4
     assert body4.count('ctx0.t0 = t0') == 1
+
+
+@skipif('petsc')
+def test_solve_output():
+    """
+    Verify that PETScSolve returns the correct output for
+    simple cases e.g with the identity matrix.
+    """
+    grid = Grid(shape=(11, 11), dtype=np.float64)
+
+    u = Function(name='u', grid=grid, space_order=2)
+    v = Function(name='v', grid=grid, space_order=2)
+
+    # Solving Ax=b where A is the identity matrix
+    v.data[:] = 5.0
+    eqn = Eq(u, v)
+    petsc = PETScSolve(eqn, target=u)
+
+    op = Operator(petsc)
+    # Check the solve function returns the correct output
+    op.apply()
+
+    assert np.allclose(u.data, v.data)
 
 
 class TestCoupledLinear:
@@ -796,7 +776,7 @@ class TestCoupledLinear:
     def test_coupled_vs_non_coupled(self):
         grid = Grid(shape=(11, 11), dtype=np.float64)
 
-        functions = [Function(name=n, grid=grid, space_order=2, dtype=np.float64)
+        functions = [Function(name=n, grid=grid, space_order=2)
                      for n in ['e', 'f', 'g', 'h']]
         e, f, g, h = functions
 
@@ -810,8 +790,7 @@ class TestCoupledLinear:
         petsc1 = PETScSolve(eq1, target=e)
         petsc2 = PETScSolve(eq2, target=g)
 
-        with switchconfig(openmp=False):
-            op1 = Operator(petsc1 + petsc2, opt='noop')
+        op1 = Operator(petsc1 + petsc2, opt='noop')
         op1.apply()
 
         enorm1 = norm(e)
@@ -825,8 +804,8 @@ class TestCoupledLinear:
         # TODO: Need more friendly API for coupled - just
         # using a dict for now
         petsc3 = PETScSolve({e: [eq1], g: [eq2]})
-        with switchconfig(openmp=False):
-            op2 = Operator(petsc3, opt='noop')
+
+        op2 = Operator(petsc3, opt='noop')
         op2.apply()
 
         enorm2 = norm(e)
@@ -856,9 +835,9 @@ class TestCoupledLinear:
 
     @skipif('petsc')
     def test_coupled_structs(self):
-        grid = Grid(shape=(11, 11))
+        grid = Grid(shape=(11, 11), dtype=np.float64)
 
-        functions = [Function(name=n, grid=grid, space_order=2, dtype=np.float64)
+        functions = [Function(name=n, grid=grid, space_order=2)
                      for n in ['e', 'f', 'g', 'h']]
         e, f, g, h = functions
 
@@ -868,8 +847,8 @@ class TestCoupledLinear:
         petsc = PETScSolve({f: [eq1], h: [eq2]})
 
         name = "foo"
-        with switchconfig(openmp=False):
-            op = Operator(petsc, name=name)
+
+        op = Operator(petsc, name=name)
 
         # Trigger the generation of a .c and a .h files
         ccode, hcode = op.cinterface(force=True)
@@ -899,7 +878,7 @@ class TestCoupledLinear:
     def test_coupled_frees(self):
         grid = Grid(shape=(11, 11), dtype=np.float64)
 
-        functions = [Function(name=n, grid=grid, space_order=2, dtype=np.float64)
+        functions = [Function(name=n, grid=grid, space_order=2)
                      for n in ['e', 'f', 'g', 'h']]
         e, f, g, h = functions
 
@@ -910,9 +889,8 @@ class TestCoupledLinear:
         petsc1 = PETScSolve({e: [eq1], f: [eq2]})
         petsc2 = PETScSolve({e: [eq1], f: [eq2], g: [eq3]})
 
-        with switchconfig(openmp=False):
-            op1 = Operator(petsc1, opt='noop')
-            op2 = Operator(petsc2, opt='noop')
+        op1 = Operator(petsc1, opt='noop')
+        op2 = Operator(petsc2, opt='noop')
 
         frees1 = op1.body.frees
         frees2 = op2.body.frees
@@ -941,9 +919,9 @@ class TestCoupledLinear:
 
     @skipif('petsc')
     def test_dmda_dofs(self):
-        grid = Grid(shape=(11, 11))
+        grid = Grid(shape=(11, 11), dtype=np.float64)
 
-        functions = [Function(name=n, grid=grid, space_order=2, dtype=np.float64)
+        functions = [Function(name=n, grid=grid, space_order=2)
                      for n in ['e', 'f', 'g', 'h']]
         e, f, g, h = functions
 
@@ -955,10 +933,9 @@ class TestCoupledLinear:
         petsc2 = PETScSolve({e: [eq1], f: [eq2]})
         petsc3 = PETScSolve({e: [eq1], f: [eq2], g: [eq3]})
 
-        with switchconfig(openmp=False):
-            op1 = Operator(petsc1, opt='noop')
-            op2 = Operator(petsc2, opt='noop')
-            op3 = Operator(petsc3, opt='noop')
+        op1 = Operator(petsc1, opt='noop')
+        op2 = Operator(petsc2, opt='noop')
+        op3 = Operator(petsc3, opt='noop')
 
         # Check the number of dofs in the DMDA for each field
         assert 'PetscCall(DMDACreate2d(PETSC_COMM_WORLD,DM_BOUNDARY_GHOSTED,' + \
@@ -975,9 +952,9 @@ class TestCoupledLinear:
 
     @skipif('petsc')
     def test_submatrices(self):
-        grid = Grid(shape=(11, 11))
+        grid = Grid(shape=(11, 11), dtype=np.float64)
 
-        functions = [Function(name=n, grid=grid, space_order=2, dtype=np.float64)
+        functions = [Function(name=n, grid=grid, space_order=2)
                      for n in ['e', 'f', 'g', 'h']]
         e, f, g, h = functions
 

--- a/tests/test_petsc.py
+++ b/tests/test_petsc.py
@@ -671,7 +671,8 @@ def test_start_ptr():
         op1 = Operator(petsc1)
 
     # Verify the case with modulo time stepping
-    assert 'PetscScalar * u1_ptr0 = t1*localsize0 + (PetscScalar*)(u1_vec->data);' in str(op1)
+    assert ('PetscScalar * u1_ptr0 = t1*localsize0 + '
+        '(PetscScalar*)(u1_vec->data);') in str(op1)
 
     # Verify the case with no modulo time stepping
     u2 = TimeFunction(name='u2', grid=grid, space_order=2, save=5)
@@ -681,8 +682,8 @@ def test_start_ptr():
     with switchconfig(language='petsc'):
         op2 = Operator(petsc2)
 
-    assert 'PetscScalar * u2_ptr0 = (time + 1)*localsize0 + ' + \
-        '(PetscScalar*)(u2_vec->data);' in str(op2)
+    assert ('PetscScalar * u2_ptr0 = (time + 1)*localsize0 + '
+        '(PetscScalar*)(u2_vec->data);') in str(op2)
 
 
 @skipif('petsc')


### PR DESCRIPTION
TODO:
Extend the PETSc printer to automatically replace specific types, such as converting int to the corresponding PETSc type (e.g., PetscInt).